### PR TITLE
Don't store bindata metadata

### DIFF
--- a/cli/Makefile
+++ b/cli/Makefile
@@ -46,7 +46,7 @@ install: build
 .PHONY: assets
 assets:
 	@mkdir -p $(ASSETS_DIR)
-	go run github.com/go-bindata/go-bindata/go-bindata -o $(ASSETS_DIR)/$(ASSETS_PACKAGE).go -pkg $(ASSETS_PACKAGE) -prefix $(ASSETS_INPUT)/ $(ASSETS_INPUT)
+	go run github.com/go-bindata/go-bindata/go-bindata -nometadata -o $(ASSETS_DIR)/$(ASSETS_PACKAGE).go -pkg $(ASSETS_PACKAGE) -prefix $(ASSETS_INPUT)/ $(ASSETS_INPUT)
 
 .PHONY: clean-assets
 clean-assets:

--- a/cli/pkg/assets/assets.go
+++ b/cli/pkg/assets/assets.go
@@ -94,7 +94,7 @@ func dockerfile() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "Dockerfile", size: 489, mode: os.FileMode(420), modTime: time.Unix(1595363896, 0)}
+	info := bindataFileInfo{name: "Dockerfile", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -114,7 +114,7 @@ func baseimagesBaseDockerfile() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "baseimages-base.Dockerfile", size: 1201, mode: os.FileMode(420), modTime: time.Unix(1595363896, 0)}
+	info := bindataFileInfo{name: "baseimages-base.Dockerfile", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -134,7 +134,7 @@ func baseimagesPackagesDockerfile() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "baseimages-packages.Dockerfile", size: 57, mode: os.FileMode(420), modTime: time.Unix(1595363896, 0)}
+	info := bindataFileInfo{name: "baseimages-packages.Dockerfile", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
Stops the modtime getting updated on every install.