### PR TITLE
Remove host from list

### DIFF
--- a/cli/pkg/list/list.go
+++ b/cli/pkg/list/list.go
@@ -120,7 +120,7 @@ func outputTable(experiments []*ListExperiment, allParams bool) error {
 
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-	keys := []string{"EXPERIMENT", "STARTED", "STATUS", "HOST", "USER"}
+	keys := []string{"EXPERIMENT", "STARTED", "STATUS", "USER"}
 	keys = append(keys, upper(expHeadings)...)
 	keys = append(keys, "LATEST COMMIT")
 	keys = append(keys, upper(commitHeadings)...)
@@ -150,9 +150,6 @@ func outputTable(experiments []*ListExperiment, allParams bool) error {
 		} else {
 			fmt.Fprint(tw, "stopped\t")
 		}
-
-		// host
-		fmt.Fprintf(tw, "%s\t", exp.Host)
 
 		// user
 		fmt.Fprintf(tw, "%s\t", exp.User)

--- a/cli/pkg/list/list_test.go
+++ b/cli/pkg/list/list_test.go
@@ -129,10 +129,10 @@ func TestOutputTableWithPrimaryMetricOnlyChangedParams(t *testing.T) {
 	})
 	require.NoError(t, err)
 	expected := `
-EXPERIMENT  STARTED             STATUS   HOST      USER     PARAM-1  LATEST COMMIT      LABEL-1  LABEL-3  BEST COMMIT        LABEL-1  LABEL-3
-3eeeeee     2 minutes ago       stopped  10.1.1.2  ben      200
-1eeeeee     about a second ago  running  10.1.1.1  andreas  100      3cccccc (step 20)  0.02              2cccccc (step 20)  0.01
-2eeeeee     about a minute ago  stopped  10.1.1.2  andreas  200      4cccccc (step 5)            0.5
+EXPERIMENT  STARTED             STATUS   USER     PARAM-1  LATEST COMMIT      LABEL-1  LABEL-3  BEST COMMIT        LABEL-1  LABEL-3
+3eeeeee     2 minutes ago       stopped  ben      200
+1eeeeee     about a second ago  running  andreas  100      3cccccc (step 20)  0.02              2cccccc (step 20)  0.01
+2eeeeee     about a minute ago  stopped  andreas  200      4cccccc (step 5)            0.5
 `
 	expected = expected[1:] // strip initial whitespace, added for readability
 	actual = trimRightLines(actual)
@@ -162,10 +162,10 @@ func TestOutputTableWithPrimaryMetricAllParams(t *testing.T) {
 	})
 	require.NoError(t, err)
 	expected := `
-EXPERIMENT  STARTED             STATUS   HOST      USER     PARAM-1  PARAM-2  PARAM-3  LATEST COMMIT      LABEL-1  LABEL-3  BEST COMMIT        LABEL-1  LABEL-3
-3eeeeee     2 minutes ago       stopped  10.1.1.2  ben      200      hello    hi
-1eeeeee     about a second ago  running  10.1.1.1  andreas  100      hello             3cccccc (step 20)  0.02              2cccccc (step 20)  0.01
-2eeeeee     about a minute ago  stopped  10.1.1.2  andreas  200      hello    hi       4cccccc (step 5)            0.5
+EXPERIMENT  STARTED             STATUS   USER     PARAM-1  PARAM-2  PARAM-3  LATEST COMMIT      LABEL-1  LABEL-3  BEST COMMIT        LABEL-1  LABEL-3
+3eeeeee     2 minutes ago       stopped  ben      200      hello    hi
+1eeeeee     about a second ago  running  andreas  100      hello             3cccccc (step 20)  0.02              2cccccc (step 20)  0.01
+2eeeeee     about a minute ago  stopped  andreas  200      hello    hi       4cccccc (step 5)            0.5
 `
 	expected = expected[1:] // strip initial whitespace, added for readability
 	actual = trimRightLines(actual)


### PR DESCRIPTION
Pulled this out as a separate PR from #53. Discussion here: https://github.com/replicate/replicate/pull/53#discussion_r466522697.

This is probably not the right solution, as per discussion, but gives us a place to discuss and work around it.

Original commit message:

This is wide and isn't that useful:
- When it is running, you probably only need to know the host
  when something is broke. In which case, use show.
- When it is stopped, you don't really have any reason to know it
  besides posterity.

A valid use case I can think of is figuring out which machines are
being used, but that feels like a bodge that needs a better solution.