### PR TITLE
mounts in replicate run

### DIFF
--- a/cli/pkg/docker/run_test.go
+++ b/cli/pkg/docker/run_test.go
@@ -1,0 +1,36 @@
+package docker
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"path"
+	"testing"
+
+	"github.com/kami-zh/go-capturer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunMounts(t *testing.T) {
+	dockerClient, err := NewLocalClient()
+	require.NoError(t, err)
+
+	tmpdir, err := ioutil.TempDir("/tmp", "test-run")
+	require.NoError(t, err)
+
+	err = ioutil.WriteFile(path.Join(tmpdir, "hello.txt"), []byte("hello\n"), 0644)
+	require.NoError(t, err)
+
+	mounts := []Mount{{
+		HostDir:      tmpdir,
+		ContainerDir: "/mounted",
+	}}
+
+	// docker.Run doesn't pull
+	require.NoError(t, exec.Command("docker", "pull", "alpine").Run())
+
+	out := capturer.CaptureStdout(func() {
+		err = Run(dockerClient, "alpine", []string{"cat", "/mounted/hello.txt"}, mounts, false, "user", "host", "s3://storage-bucket")
+	})
+	require.NoError(t, err)
+	require.Equal(t, "hello\n", out)
+}


### PR DESCRIPTION
Added a repeatable `-m`/`--mount` option to `replicate run`.

We should probably think about putting data directories in `replicate.yaml` at some point, since training runs won't work without them.