### PR TITLE
Use fancy build output

### DIFF
--- a/cli/pkg/docker/build.go
+++ b/cli/pkg/docker/build.go
@@ -17,7 +17,6 @@ func Build(remoteOptions *remote.Options, folder string, dockerfile string, name
 		"build", ".",
 		"--build-arg", "BUILDKIT_INLINE_CACHE=1",
 		"--build-arg", "BASE_IMAGE=" + baseImage,
-		"--progress", "plain",
 		"--file", "-",
 		"--tag", name,
 	}


### PR DESCRIPTION
This isn't the most user-friendly thing lol

<img width="760" alt="Screen Shot 2020-08-11 at 15 18 21" src="https://user-images.githubusercontent.com/40906/89954590-3ec0b880-dbe6-11ea-8996-a60d3d5b7938.png">

I think this might have been changed when we switched away from openssh, but now we're using it again, may as well. It does a much better job of surfacing errors and hiding noise, too.
