### PR TITLE
relax cuda/torch compatibility requirements

### DIFF
--- a/base-image-builder/go.sum
+++ b/base-image-builder/go.sum
@@ -45,6 +45,7 @@ github.com/apex/log v1.1.2/go.mod h1:SyfRweFO+TlkIJ3DVizTSeI1xk7jOIIqOnUPZQTTsww
 github.com/apex/logs v0.0.3/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
+github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1/go.mod h1:SLqhdZcd+dF3TEVL2RMoob5bBP5R1P1qkox+HtCBgGI=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.33.2/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
@@ -199,6 +200,7 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
+github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=

--- a/cli/pkg/baseimages/baseimages.go
+++ b/cli/pkg/baseimages/baseimages.go
@@ -169,7 +169,7 @@ func (c PyTorchMeta) GetCuDNN() CuDNN {
 }
 
 func (c PyTorchMeta) FrameworkString() string {
-	return fmt.Sprintf("pytorch%s", c.Torch)
+	return fmt.Sprintf("pytorch%s", c.Version())
 }
 
 func (c PyTorchMeta) Name() string {
@@ -184,6 +184,14 @@ func (c PyTorchMeta) Version() string {
 	return c.Torch
 }
 
+func (c *PyTorchMeta) versionSansCUDA() string {
+	if strings.Contains(c.Torch, "+") {
+		parts := strings.SplitN(c.Torch, "+", 2)
+		return parts[0]
+	}
+	return c.Torch
+}
+
 var (
 	PythonVersions = []Python{
 		Py38,
@@ -193,11 +201,12 @@ var (
 		Py27,
 	}
 
-	// from https://www.tensorflow.org/install/source#tested_build_configurations,
+	// from https://www.tensorflow.org/install/source#gpu
 	// though some python versions are actually missing when you
 	// try to install tensorflow. e.g. py3.6.11 doesn't have a
 	// pypi candidate for tensorflow==2.2.0 on linux
 	TensorflowMetas = []TensorflowMeta{
+		{"2.3.0", "tensorflow==2.3.0", "tensorflow==2.3.0", CUDA10_1, CuDNN7, []Python{Py35, Py37, Py38}},
 		{"2.2.0", "tensorflow==2.2.0", "tensorflow==2.2.0", CUDA10_1, CuDNN7, []Python{Py35, Py37, Py38}},
 		{"2.1.0", "tensorflow==2.1.0", "tensorflow==2.1.0", CUDA10_1, CuDNN7, []Python{Py37, Py27}},
 		{"2.0.1", "tensorflow==2.0.1", "tensorflow==2.0.1", CUDA10_0, CuDNN7, []Python{Py37}},
@@ -233,9 +242,17 @@ var (
 	}
 
 	PyTorchMetas = []PyTorchMeta{
+		{"1.6.0", "0.7.0", CUDA10_2, CuDNN7, []Python{Py38, Py37, Py36}},
+		{"1.6.0+cu101", "0.7.0+cu101", CUDA10_1, CuDNN7, []Python{Py38, Py37, Py36}},
+		{"1.6.0+cu92", "0.7.0+cu92", CUDA9_2, CuDNN7, []Python{Py38, Py37, Py36}},
 		{"1.5.1", "0.6.1", CUDA10_2, CuDNN7, []Python{Py38, Py37, Py36}},
+		{"1.5.1+cu101", "0.6.1+cu101", CUDA10_1, CuDNN7, []Python{Py38, Py37, Py36}},
+		{"1.5.1+cu92", "0.6.1+cu92", CUDA9_2, CuDNN7, []Python{Py38, Py37, Py36}},
 		{"1.5.0", "0.6.0", CUDA10_2, CuDNN7, []Python{Py38, Py37, Py36}},
+		{"1.5.0+cu101", "0.6.0+cu101", CUDA10_1, CuDNN7, []Python{Py38, Py37, Py36}},
+		{"1.5.0+cu92", "0.6.0+cu92", CUDA9_2, CuDNN7, []Python{Py38, Py37, Py36}},
 		{"1.4.0", "0.5.0", CUDA10_1, CuDNN7, []Python{Py38, Py37, Py36, Py27}},
+		{"1.4.0+cu92", "0.5.0+cu92", CUDA9_2, CuDNN7, []Python{Py38, Py37, Py36, Py27}},
 		{"1.2.0", "0.4.0", CUDA10_0, CuDNN7, []Python{Py37, Py36, Py27}},
 		{"1.1.0", "0.3.0", CUDA10_0, CuDNN7, []Python{Py37, Py36, Py27}},
 		{"1.0.1", "0.2.2", CUDA10_0, CuDNN7, []Python{Py37, Py36, Py35, Py27}},
@@ -243,21 +260,21 @@ var (
 	}
 
 	CUDAImages = map[CUDACuDNNUbuntu]string{
-		CUDACuDNNUbuntu{CUDA10_2, CuDNN8, Ubuntu18_04}: "nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04",
-		CUDACuDNNUbuntu{CUDA10_2, CuDNN8, Ubuntu16_04}: "nvidia/cuda:10.2-cudnn8-devel-ubuntu16.04",
-		CUDACuDNNUbuntu{CUDA10_2, CuDNN7, Ubuntu18_04}: "nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04",
-		CUDACuDNNUbuntu{CUDA10_2, CuDNN7, Ubuntu16_04}: "nvidia/cuda:10.2-cudnn7-devel-ubuntu16.04",
-		CUDACuDNNUbuntu{CUDA10_1, CuDNN7, Ubuntu18_04}: "nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04",
-		CUDACuDNNUbuntu{CUDA10_1, CuDNN7, Ubuntu16_04}: "nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04",
-		CUDACuDNNUbuntu{CUDA10_0, CuDNN7, Ubuntu18_04}: "nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04",
-		CUDACuDNNUbuntu{CUDA10_0, CuDNN7, Ubuntu16_04}: "nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04",
-		CUDACuDNNUbuntu{CUDA9_2, CuDNN7, Ubuntu18_04}:  "nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04",
-		CUDACuDNNUbuntu{CUDA9_2, CuDNN7, Ubuntu16_04}:  "nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04",
-		CUDACuDNNUbuntu{CUDA9_1, CuDNN7, Ubuntu16_04}:  "nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04",
-		CUDACuDNNUbuntu{CUDA9_0, CuDNN7, Ubuntu16_04}:  "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
-		CUDACuDNNUbuntu{CUDA8_0, CuDNN7, Ubuntu16_04}:  "nvidia/cuda:8.0-cudnn7-devel-ubuntu16.04",
-		CUDACuDNNUbuntu{CUDA8_0, CuDNN6, Ubuntu16_04}:  "nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04",
-		CUDACuDNNUbuntu{CUDA8_0, CuDNN5, Ubuntu16_04}:  "nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04",
+		{CUDA10_2, CuDNN8, Ubuntu18_04}: "nvidia/cuda:10.2-cudnn8-devel-ubuntu18.04",
+		{CUDA10_2, CuDNN8, Ubuntu16_04}: "nvidia/cuda:10.2-cudnn8-devel-ubuntu16.04",
+		{CUDA10_2, CuDNN7, Ubuntu18_04}: "nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04",
+		{CUDA10_2, CuDNN7, Ubuntu16_04}: "nvidia/cuda:10.2-cudnn7-devel-ubuntu16.04",
+		{CUDA10_1, CuDNN7, Ubuntu18_04}: "nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04",
+		{CUDA10_1, CuDNN7, Ubuntu16_04}: "nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04",
+		{CUDA10_0, CuDNN7, Ubuntu18_04}: "nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04",
+		{CUDA10_0, CuDNN7, Ubuntu16_04}: "nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04",
+		{CUDA9_2, CuDNN7, Ubuntu18_04}:  "nvidia/cuda:9.2-cudnn7-devel-ubuntu18.04",
+		{CUDA9_2, CuDNN7, Ubuntu16_04}:  "nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04",
+		{CUDA9_1, CuDNN7, Ubuntu16_04}:  "nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04",
+		{CUDA9_0, CuDNN7, Ubuntu16_04}:  "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+		{CUDA8_0, CuDNN7, Ubuntu16_04}:  "nvidia/cuda:8.0-cudnn7-devel-ubuntu16.04",
+		{CUDA8_0, CuDNN6, Ubuntu16_04}:  "nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04",
+		{CUDA8_0, CuDNN5, Ubuntu16_04}:  "nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04",
 	}
 
 	// from https://docs.nvidia.com/deploy/cuda-compatibility/index.html#binary-compatibility__table-toolkit-driver
@@ -376,4 +393,49 @@ func LatestFrameworkVersion(framework string) string {
 
 func LatestUbuntu() Ubuntu {
 	return Ubuntu18_04
+}
+
+func CudaCompatibilityError(requestedCUDA CUDA, hostCUDADriverVersion string, frameworkMeta FrameworkMeta) error {
+	supportedCUDA, err := LatestCUDAForDriverVersion(hostCUDADriverVersion)
+	if err != nil {
+		return err
+	}
+	defaultErr := fmt.Errorf(`CUDA %s is not compatible with your host's CUDA driver version %s.
+The latest supported CUDA version is %s.
+
+Please refer to https://docs.nvidia.com/deploy/cuda-compatibility/index.html#binary-compatibility__table-toolkit-driver for the correct driver version.`, requestedCUDA, supportedCUDA, hostCUDADriverVersion)
+	if frameworkMeta == nil {
+		return defaultErr
+	}
+	if torchMeta, ok := frameworkMeta.(PyTorchMeta); ok {
+		compatibleTorchMeta := cudaCompatiblePyTorchMeta(torchMeta, requestedCUDA)
+		if compatibleTorchMeta == nil {
+			return fmt.Errorf(`pytorch==%s requires at least CUDA version %s.
+Your host's CUDA driver version %s supports CUDA version %s and below.
+
+Please refer to https://pytorch.org/ and https://pytorch.org/get-started/previous-versions/ for PyTorch/CUDA compatibility, and https://docs.nvidia.com/deploy/cuda-compatibility/index.html#binary-compatibility__table-toolkit-driver for information on CUDA driver versions`, torchMeta.versionSansCUDA(), torchMeta.CUDA, hostCUDADriverVersion, supportedCUDA)
+		}
+		return fmt.Errorf(`pytorch==%s requires at least CUDA version %s.
+Your host's CUDA driver version %s supports CUDA version %s and below.
+To use pytorch %s with CUDA %s, change the pytorch version to pytorch==%s.
+
+Please refer to https://pytorch.org/ and https://pytorch.org/get-started/previous-versions/ for PyTorch/CUDA compatibility, and https://docs.nvidia.com/deploy/cuda-compatibility/index.html#binary-compatibility__table-toolkit-driver for information on CUDA driver versions`, torchMeta.versionSansCUDA(), torchMeta.CUDA, hostCUDADriverVersion, supportedCUDA, torchMeta.versionSansCUDA(), torchMeta.CUDA, compatibleTorchMeta.Torch)
+	}
+	if tfMeta, ok := frameworkMeta.(TensorflowMeta); ok {
+		return fmt.Errorf(`tensorflow==%s requires at least CUDA version %s.
+Your host's CUDA driver version %s supports CUDA version %s and below.
+
+Please refer to https://www.tensorflow.org/install/source#gpu for TensorFlow/CUDA compatibility, and https://docs.nvidia.com/deploy/cuda-compatibility/index.html#binary-compatibility__table-toolkit-driver for information on CUDA driver versions`, tfMeta.Version(), tfMeta.CUDA, hostCUDADriverVersion, supportedCUDA)
+	}
+
+	return defaultErr
+}
+
+func cudaCompatiblePyTorchMeta(torchMeta PyTorchMeta, cuda CUDA) *PyTorchMeta {
+	for _, t := range PyTorchMetas {
+		if t.versionSansCUDA() == torchMeta.versionSansCUDA() && t.CUDA == cuda {
+			return &t
+		}
+	}
+	return nil
 }

--- a/cli/pkg/baseimages/build_test.go
+++ b/cli/pkg/baseimages/build_test.go
@@ -22,5 +22,5 @@ func TestCountBaseImages(t *testing.T) {
 	b := &CountBuilder{}
 	err := BuildBaseImages(b, "project", "registry", "0.1", 0)
 	require.NoError(t, err)
-	require.Equal(t, 315, int(b.count))
+	require.Equal(t, 371, int(b.count))
 }

--- a/cli/pkg/build/build.go
+++ b/cli/pkg/build/build.go
@@ -110,7 +110,7 @@ func getCUDAVersion(conf *config.Config, frameworkMeta baseimages.FrameworkMeta,
 				return "", "", err
 			}
 			if !driverCompatible {
-				return "", "", cudaCompatibilityError(cuda, hostCUDADriverVersion)
+				return "", "", baseimages.CudaCompatibilityError(cuda, hostCUDADriverVersion, nil)
 			}
 			cuDNN := baseimages.LatestCuDNNForCUDA[cuda]
 
@@ -145,7 +145,7 @@ func getCUDAVersion(conf *config.Config, frameworkMeta baseimages.FrameworkMeta,
 		return "", "", err
 	}
 	if !driverCompatible {
-		return "", "", cudaCompatibilityError(cuda, hostCUDADriverVersion)
+		return "", "", baseimages.CudaCompatibilityError(cuda, hostCUDADriverVersion, frameworkMeta)
 	}
 
 	return cuda, cuDNN, err
@@ -188,8 +188,4 @@ func getFrameworkMeta(frameworkName string, version string) (baseimages.Framewor
 		return nil, err
 	}
 	return meta, nil
-}
-
-func cudaCompatibilityError(requestedCUDA baseimages.CUDA, hostCUDADriverVersion string) error {
-	return fmt.Errorf("CUDA %s is not compatible with your host's CUDA driver version %s.\nPlease refer to https://docs.nvidia.com/deploy/cuda-compatibility/index.html#binary-compatibility__table-toolkit-driver for the correct driver version.", requestedCUDA, hostCUDADriverVersion)
 }

--- a/cli/pkg/build/build_test.go
+++ b/cli/pkg/build/build_test.go
@@ -74,11 +74,12 @@ torch==1.2.0
 
 `
 	torchWithBadVersion := `torch==bad`
+	torchWithCudaVersion := `torch==1.6.0+cu92`
 
-	tf220 := baseimages.TensorflowMeta{
-		TF:           "2.2.0",
-		TFCPUPackage: "tensorflow==2.2.0",
-		TFGPUPackage: "tensorflow==2.2.0",
+	tf230 := baseimages.TensorflowMeta{
+		TF:           "2.3.0",
+		TFCPUPackage: "tensorflow==2.3.0",
+		TFGPUPackage: "tensorflow==2.3.0",
 		CUDA:         baseimages.CUDA10_1,
 		CuDNN:        baseimages.CuDNN7,
 		Pythons:      []baseimages.Python{baseimages.Py35, baseimages.Py37, baseimages.Py38},
@@ -90,6 +91,13 @@ torch==1.2.0
 		CUDA:         baseimages.CUDA10_1,
 		CuDNN:        baseimages.CuDNN7,
 		Pythons:      []baseimages.Python{baseimages.Py37, baseimages.Py27},
+	}
+	torch160cu92 := baseimages.PyTorchMeta{
+		Torch:       "1.6.0+cu92",
+		TorchVision: "0.7.0+cu92",
+		CUDA:        baseimages.CUDA9_2,
+		CuDNN:       baseimages.CuDNN7,
+		Pythons:     []baseimages.Python{baseimages.Py38, baseimages.Py37, baseimages.Py36},
 	}
 	torch120 := baseimages.PyTorchMeta{
 		Torch:       "1.2.0",
@@ -105,10 +113,11 @@ torch==1.2.0
 		isError      bool
 	}{
 		{noFramework, nil, false},
-		{tfNoVersion, tf220, false},
+		{tfNoVersion, tf230, false},
 		{tfWithVersion, tf210, false},
 		{torchWithVersion, torch120, false},
 		{torchWithBadVersion, nil, true},
+		{torchWithCudaVersion, torch160cu92, false},
 	} {
 		tmpDir, err := files.TempDir("test")
 		require.NoError(t, err)


### PR DESCRIPTION
* Add `+cu<version>`-suffixed versions, allowing users to use specific
cuda versions with pytorch.
* Give an actionable error message that describes how to use
CUDA version-specific pytorch versions

Supersedes https://github.com/replicate/replicate/pull/103