### PR TITLE
Add worker queue implementation

### DIFF
--- a/cli/pkg/concurrency/worker_queue.go
+++ b/cli/pkg/concurrency/worker_queue.go
@@ -1,0 +1,45 @@
+package concurrency
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
+)
+
+type WorkerQueue struct {
+	group *errgroup.Group
+	ctx   context.Context
+	sem   *semaphore.Weighted
+}
+
+func NewWorkerQueue(ctx context.Context, maxWorkers int) *WorkerQueue {
+	wq := &WorkerQueue{}
+	wq.group, wq.ctx = errgroup.WithContext(ctx)
+	wq.sem = semaphore.NewWeighted(int64(maxWorkers))
+	return wq
+}
+
+// Go starts a Go routine as a worker. If there are already maxWorkers running, it
+// will block until one of them finishes
+func (wq *WorkerQueue) Go(f func() error) error {
+	// Context has error, so let it fall through to Wait(), otherwise
+	// sem.Acquire will return error context.Cancelled
+	if wq.ctx.Err() != nil {
+		return nil
+	}
+	if err := wq.sem.Acquire(wq.ctx, 1); err != nil {
+		return err
+	}
+	wq.group.Go(func() error {
+		defer wq.sem.Release(1)
+		return f()
+	})
+	return nil
+}
+
+// Wait until all workers have finished their work. Any errors returned by workers will
+// be returned by this function.
+func (wq *WorkerQueue) Wait() error {
+	return wq.group.Wait()
+}

--- a/cli/pkg/storage/storage.go
+++ b/cli/pkg/storage/storage.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 )
 
+var maxWorkers = 128
+
 type Scheme string
 
 const (


### PR DESCRIPTION
(This is a self-contained thing in my metadata syncing work, separate PR just for the sake of getting some of it merged and seeing if end to end tests pass...)

Centralized this repeating pattern because it's fiddly.

The S3 implementation was correct, but there was a subtle bug in the GCS implementation because it was missing the wrapping `group.Go` -- any error in the go routine would just throw context.Cancelled because that gets returned by sem.Acquire first.