### PR TITLE
Use blank host when running locally

### DIFF
--- a/python/replicate/experiment.py
+++ b/python/replicate/experiment.py
@@ -1,5 +1,3 @@
-import urllib
-import urllib.error
 import getpass
 import os
 import datetime
@@ -97,17 +95,7 @@ class Experiment:
         host = os.environ.get("REPLICATE_HOST")
         if host is not None:
             return host
-        try:
-            external_ip = (
-                # FIXME: check this has a short timeout
-                urllib.request.urlopen("https://ident.me")
-                .read()
-                .decode("utf8")
-            )
-            return external_ip
-        except urllib.error.URLError as e:
-            sys.stderr.write("Failed to determine external IP, got error: {}".format(e))
-            return ""
+        return ""
 
     def get_command(self) -> str:
         return os.environ.get("REPLICATE_COMMAND", " ".join(sys.argv))


### PR DESCRIPTION
This:
1. Makes it clearer which ones you run locally
2. Stops really wide ipv6 addresses from messing up layout
3. Removes potential unreliable call to external service

I was considering using "localhost", but then that'd be a bit weird
for runs you do by calling it manually on a remote machine, or
when running on AI Platform or whatever.

There is potential improvement by detecting whether this is a
manual run on a remote machine, or AI Platform, or whatever,
but this seems like a step in the right direction.