### PR TITLE
Import storage when needed

### DIFF
--- a/python/replicate/storage/common.py
+++ b/python/replicate/storage/common.py
@@ -2,8 +2,6 @@ import re
 
 from .storage_base import Storage
 from .disk_storage import DiskStorage
-from .s3_storage import S3Storage
-from .gcs_storage import GCSStorage
 
 from ..exceptions import UnknownStorageBackend
 
@@ -17,8 +15,13 @@ def storage_for_url(url: str) -> Storage:
     scheme, path = match.groups()
 
     if scheme == "s3":
+        # lazy import to speed up import replicate
+        from .s3_storage import S3Storage
+
         return S3Storage(bucket=path)
     if scheme == "gs":
+        from .gcs_storage import GCSStorage
+
         return GCSStorage(bucket=path)
     if scheme == "file":
         return DiskStorage(root=path)


### PR DESCRIPTION
Before:

```
$ time python -c "import replicate"
0.48s user 0.11s system 98% cpu 0.603 total
```

After:

```
$ time python -c "import replicate"
0.08s user 0.03s system 87% cpu 0.130 total
```

Nothing compared to importing tensorflow/pytorch, but may as well
right?