### PR TITLE
WIP: vendor python dependencies

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,43 @@
+[tool.vendoring]
+destination = "replicate/_vendor/"
+requirements = "replicate/_vendor/vendor.txt"
+namespace = "replicate._vendor"
+
+protected-files = ["__init__.py", "README.rst", "vendor.txt"]
+patches-dir = ""
+
+[tool.vendoring.transformations]
+substitute = [
+  # FIXME: this might be neater and more reliable as a patch
+  { match='aiohttp\.ClientConnectionError', replace="replicate._vendor.aiohttp.ClientConnectionError" },
+  { match='aiohttp\.ClientPayloadError', replace="replicate._vendor.aiohttp.ClientPayloadError" },
+  { match='aiohttp\.ServerDisconnectedError', replace="replicate._vendor.aiohttp.ServerDisconnectedError" },
+  { match='get_distribution\(.+?\)\.version', replace="''" },
+]
+drop = [
+  "boto3/examples/",
+  "tests/",
+  # contains unnecessary scripts
+  # "bin/",
+  # pyyaml falls back to plain python
+  "_yaml.*.so",
+  # Google scatters these things around
+  "google_cloud_storage-1.23.0-py3.6-nspkg.pth",
+  "googleapis_common_protos-1.52.0-py3.8-nspkg.pth",
+  "gcloud_aio_auth-3.4.3-py3.8-nspkg.pth",
+  "gcloud_aio_storage-5.5.4-py3.8-nspkg.pth",
+  "google_api_core-1.22.1-py3.8-nspkg.pth",
+  "google_auth-1.21.0-py3.8-nspkg.pth",
+  "google_resumable_media-0.5.1-py3.8-nspkg.pth",
+  "protobuf-3.13.0-py3.8-nspkg.pth",
+]
+
+[tool.vendoring.typing-stubs]
+
+[tool.vendoring.license.directories]
+
+[tool.vendoring.license.fallback-urls]
+boto3-stubs = "https://raw.githubusercontent.com/vemel/mypy_boto3_builder/master/LICENSE"
+mypy-boto3-s3 = "https://raw.githubusercontent.com/vemel/mypy_boto3_builder/master/LICENSE"
+googleapis-common-protos = "https://raw.githubusercontent.com/googleapis/api-common-protos/master/LICENSE"
+protobuf = "https://raw.githubusercontent.com/protocolbuffers/protobuf/master/LICENSE"

--- a/python/replicate/_vendor/vendor.txt
+++ b/python/replicate/_vendor/vendor.txt
@@ -1,0 +1,42 @@
+aiobotocore==1.0.7
+    aioitertools==0.7.0
+    wrapt==1.12.1
+aiohttp==3.6.2
+    async_timeout==3.0.1
+    attrs==20.1.0
+    chardet==3.0.4
+    idna==2.10
+    idna_ssl==1.1.0
+    multidict==4.7.6
+    yarl==1.5.1
+boto3-stubs[essential]==1.12.32.0
+boto3==1.12.32
+    s3transfer==0.3.3
+botocore==1.15.32
+    docutils==0.15.2
+    jmespath==0.10.0
+    python_dateutil==2.8.1
+    urllib3==1.25.10
+#gcloud-aio-storage==5.5.4
+#    gcloud_aio_auth==3.4.3
+#        backoff==1.10.0
+#        cryptography==3.1
+#        future==0.18.2
+#        PyJWT==1.7.1
+google-api-core==1.22.1
+    googleapis_common_protos==1.52.0
+    protobuf==3.13.0
+    requests==2.24.0
+    pytz==2020.1
+google-auth==1.21.0
+    cachetools==4.1.1
+    pyasn1_modules==0.2.8
+    rsa==4.6
+google-cloud-storage==1.23.0
+    google-resumable-media==0.5.1
+mypy-boto3-s3==1.14.54.0
+pyyaml==5.3.1
+# used by dateutil and others
+six==1.15.0
+typing-extensions==3.7.4.3
+certifi==2020.6.20

--- a/python/replicate/config.py
+++ b/python/replicate/config.py
@@ -1,6 +1,8 @@
 import os
-import yaml
 from typing import List
+
+from ._vendor import yaml
+
 
 # TODO (bfirsh): send users to replicate.yaml reference if this is raised!
 class ConfigValidationError(Exception):

--- a/python/replicate/storage/gcs_storage.py
+++ b/python/replicate/storage/gcs_storage.py
@@ -6,12 +6,14 @@ import binascii
 import os
 import asyncio
 from typing import AnyStr, Optional, Generator, Set, Tuple
-import aiohttp
-from gcloud.aio.storage import Storage as AioStorage  # type: ignore
-from google.cloud import storage  # type: ignore
-from google.api_core import exceptions  # type: ignore
-from google.auth.credentials import Credentials  # type: ignore
-from google.oauth2 import service_account  # type: ignore
+
+from .._vendor import aiohttp
+
+# from .._vendor.gcloud.aio.storage import Storage as AioStorage  # type: ignore
+from .._vendor.google.cloud import storage  # type: ignore
+from .._vendor.google.api_core import exceptions  # type: ignore
+from .._vendor.google.auth.credentials import Credentials  # type: ignore
+from .._vendor.google.oauth2 import service_account  # type: ignore
 
 from .storage_base import Storage, ListFileInfo
 from ..exceptions import DoesNotExistError

--- a/python/replicate/storage/s3_storage.py
+++ b/python/replicate/storage/s3_storage.py
@@ -4,9 +4,10 @@ import os
 import asyncio
 import re
 from typing import AnyStr, Optional, Generator, Set, Any
-import aiobotocore  # type: ignore
-import boto3
-import mypy_boto3_s3 as s3
+
+from .._vendor import aiobotocore  # type: ignore
+from .._vendor import boto3
+from .._vendor import mypy_boto3_s3 as s3
 
 from .storage_base import Storage, ListFileInfo
 from ..exceptions import DoesNotExistError

--- a/python/replicate/storage/storage_base.py
+++ b/python/replicate/storage/storage_base.py
@@ -6,7 +6,7 @@ from typing import AnyStr, Generator, Tuple
 if sys.version_info >= (3, 8):
     from typing import TypedDict
 else:
-    from typing_extensions import TypedDict
+    from .._vendor.typing_extensions import TypedDict
 
 ListFileInfo = TypedDict("ListFileInfo", {"name": str, "type": str})
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,14 +20,14 @@ setuptools.setup(
     # TODO (bfirsh): maybe vendor all dependencies to make it not collide with other things you have installed
     # and break in weird ways?
     install_requires=[
-        "aiobotocore==1.0.7",
-        "boto3-stubs[essential]==1.12.32.0",
-        "boto3==1.12.32",
-        "botocore==1.15.32",
-        "gcloud-aio-storage==5.5.4",
-        "google-cloud-storage==1.23.0",
-        "pyyaml==5.3.1",
-        "typing-extensions",
+        # "aiobotocore==1.0.7",
+        # "boto3-stubs[essential]==1.12.32.0",
+        # "boto3==1.12.32",
+        # "botocore==1.15.32",
+        # "gcloud-aio-storage==5.5.4",
+        # "google-cloud-storage==1.23.0",
+        # "pyyaml==5.3.1",
+        # "typing-extensions",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
Putting my WIP here in case it's interesting. Uses an undocumented, little used library called [vendoring](https://github.com/pradyunsg/vendoring), which was built for pip. It's really solid and has loads of features, despite the lack of docs.

This is missing the actual vendored libraries, which we would commit to the repo for real.

As discussed on call:
- This is workable, but is a day or two's work, not an hour's
- Requires a lot of patching, like playing whack-a-mole
- The length of the whack-a-mole game is proportional to the number of dependencies we have, and the aio libraries are most of the dependencies

This uses my fork, which has a little hack to make some imports work: https://github.com/bfirsh/vendoring

Might be better to implement that as explicit patches though, because my hack might introduce unforeseen bugs.