### PR TITLE
Distribute CLI in Python package

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -16,11 +16,25 @@ lint:
 
 .PHONY: clean
 clean:
-	rm -rf dist
+	rm -rf build dist
 
+# Build packages for the various platforms.
+# setup.py handles converting these platform names into Go platforms.
+#
+# One trick worth noting with the build system: we're building "pure" Python
+# libraries, that theoretically aren't tied to any Python runtime or platform.
+# But, handily, wheel lets us override the platform with --plat-name even when it is a pure library:
+# https://github.com/pypa/wheel/blob/730e3ae7427682435af9572126d2722adf7c438c/src/wheel/bdist_wheel.py#L237-L240
+# I'm not sure we really should be doing this, because setting platform seems to be designed
+# for non-pure modules, but what the heck, this seems to work?
+# Anyway -- I'm writing this down here because if this stops working at some point in
+# the future it's because wheel changed their logic around pure modules.
 .PHONY: build
 build: clean
-	python setup.py sdist
+	pip install wheel
+	python setup.py bdist_wheel --plat-name linux_i686
+	python setup.py bdist_wheel --plat-name linux_x86_64
+	python setup.py bdist_wheel --plat-name macosx_10_9_x86_64
 
 .PHONY: targets
 targets:

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,9 +1,83 @@
 # type: ignore
-
+from distutils.command.build_scripts import build_scripts as _build_scripts
+from distutils.util import convert_path
+import os
+from pathlib import Path
 import setuptools
+import shutil
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
+
+
+# The supported platforms we can build, passed to `python setup.py bdist_wheel --plat-name ...`
+#
+# For macosx, the version number indicates the _minimum_ version, so we just use an arbitrarily old one
+# (the same one that numpy uses *shrug*)
+# https://docs.python.org/3/distutils/apiref.html#distutils.util.get_platform
+#
+# There doesn't seem to be a good list of platforms. The best I can find is the source code of distutils:
+# https://github.com/python/cpython/blob/master/Lib/distutils/util.py
+# Inside the packaging system, it then converts "-" to "_" to produce the platform name that goes in the filename
+#
+# See also:
+# https://packaging.python.org/specifications/platform-compatibility-tags/
+# https://www.python.org/dev/peps/pep-0425/
+PLAT_NAME_TO_BINARY = {
+    "linux_i686": "linux/386/replicate",
+    "linux_x86_64": "linux/amd64/replicate",
+    "macosx_10_9_x86_64": "darwin/amd64/replicate",
+}
+
+
+# HACK: lots of setup.py commands rely on the script existing, so create a dummy one for when
+# we're not building a package
+this_dir = Path(__file__).resolve().parent
+(this_dir / "build/bin").mkdir(parents=True, exist_ok=True)
+(this_dir / "build/bin/replicate").touch()
+
+
+def copy_binary(plat_name):
+    """
+    Copy binary for platform from ../cli into current directory
+    """
+    this_dir = Path(__file__).resolve().parent
+    binary_path = this_dir / "../cli/release" / PLAT_NAME_TO_BINARY[plat_name]
+    (this_dir / "build/bin").mkdir(parents=True, exist_ok=True)
+    shutil.copy(binary_path, this_dir / "build/bin/replicate")
+
+
+# wheel isn't always installed, so only override for when we're building packages
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+    # override bdist_wheel so we can copy binary into right place before wheel is created
+    class bdist_wheel(_bdist_wheel):
+        def run(self):
+            copy_binary(self.plat_name)
+            _bdist_wheel.run(self)
+
+
+except ImportError:
+    bdist_wheel = None
+
+
+# override build_scripts so we can install binaries
+# The original expects them to be plain text:
+# https://github.com/python/cpython/blob/master/Lib/distutils/command/build_scripts.py
+class build_scripts(_build_scripts):
+    def run(self):
+        self.mkpath(self.build_dir)
+        outfiles = []
+        updated_files = []
+        for script in self.scripts:
+            script = convert_path(script)
+            outfile = os.path.join(self.build_dir, os.path.basename(script))
+            updated_files.append(outfile)
+            outfiles.append(outfile)
+            self.copy_file(script, outfile)
+        return outfiles, updated_files
+
 
 # fmt: off
 setuptools.setup(
@@ -35,6 +109,11 @@ setuptools.setup(
             "pytest==5.4.3",
             "tox==3.14.1",
         ],
-    }
+    },
+    cmdclass={
+        'bdist_wheel': bdist_wheel,
+        'build_scripts': build_scripts,
+    },
+    scripts=["build/bin/replicate"],
 )
 # fmt: on

--- a/web/docs/tutorial.md
+++ b/web/docs/tutorial.md
@@ -12,37 +12,6 @@ If you like to **learn by doing**, this guide will help you learn how Replicate 
 
 If you prefer to **learn concepts first**, take a look at [our guide about how Replicate works](how-it-works).
 
-## Install Replicate
-
-<Tabs
-groupId="operating-systems"
-defaultValue="mac"
-values={[
-{label: 'macOS', value: 'mac'},
-{label: 'Linux', value: 'linux'},
-]
-}>
-<TabItem value="mac">
-
-Run the following commands in a terminal:
-
-```shell-session
-curl -o /usr/local/bin/replicate https://storage.googleapis.com/replicate-public/cli/latest/darwin/amd64/replicate
-chmod +x /usr/local/bin/replicate
-```
-
-</TabItem>
-<TabItem value="linux">
-Run the following commands in a terminal:
-
-```shell-session
-sudo curl -o /usr/local/bin/replicate https://storage.googleapis.com/replicate-public/cli/latest/linux/amd64/replicate
-sudo chmod +x /usr/local/bin/replicate
-```
-
-</TabItem>
-</Tabs>
-
 ## Write a model
 
 We're going to make a model that classifies Iris plants, trained on the [Iris dataset](https://archive.ics.uci.edu/ml/datasets/iris). It's an intentionally simple model that trains really fast, just so we can show you how Replicate works.


### PR DESCRIPTION
This was... involved.

This was a preparatory piece of work for using the Go storage in Python. A big unknown was whether we could actually build the wheels. I didn't know whether it was possible to 1) do this outside of Python's C library build system and 2) make cross-platform builds. Turns out it is possible to do both of these things, with bodging! So, including the shared Go libraries in wheels is now just a matter of sticking the `.so` file in package_data.

A summary of how this works:

1. Makefile calls bdist_wheel for each platform we want to build
2. setup.py overrides bdist_wheel to pull in the correct CLI version for that platform
3. setup.py overrides build_scripts to put binaries into right place in package (it normally assumes they are Python files)

Lots of comments inline about the details.

I have tested this both on my OS X machine and on fresh Linux in Docker. Eyeballing our release CI job it looks like it should still work, but that's an unknown we should test on next release.