### PR TITLE
Pull out Keras docs as a guide

### DIFF
--- a/web/docs/keras-integration.md
+++ b/web/docs/keras-integration.md
@@ -1,0 +1,64 @@
+---
+id: keras-integration
+title: Keras integration
+---
+
+_Note: This is an experimental feature, and the API may change in the future._
+
+Replicate works with any machine learning framework, but it includes a callback that makes it easier to use with Keras.
+
+`ReplicateCallback` behaves like [Tensorflow's `ModelCheckpoint` callback](https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/ModelCheckpoint), but in addition to exporting a model at the end of each epoch, it also:
+
+1. Calls `replicate.init()` at the start of training to create an experiment, and
+2. Calls `experiment.checkpoint()` after saving the model at the end of the epoch. All metrics are saved, and also any data from the [`logs` dictionary passed to the callback's `on_epoch_end` method](https://www.tensorflow.org/guide/keras/custom_callback#a_basic_example).
+
+Here is a simple example:
+
+```python
+import tensorflow as tf
+from tensorflow import keras
+# highlight-next-line
+from replicate.keras_callback import ReplicateCallback
+
+dense_size = 784
+learning_rate = 0.01
+
+# from https://www.tensorflow.org/guide/keras/custom_callback
+model = keras.Sequential()
+model.add(keras.layers.Dense(1, input_dim=dense_size))
+model.compile(
+    optimizer=keras.optimizers.RMSprop(learning_rate=learning_rate),
+    loss="mean_squared_error",
+    metrics=["mean_absolute_error"],
+)
+
+# Load example MNIST data and pre-process it
+(x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data()
+x_train = x_train.reshape(-1, 784).astype("float32") / 255.0
+x_test = x_test.reshape(-1, 784).astype("float32") / 255.0
+
+model.fit(
+    x_train[:1000],
+    y_train[:1000],
+    batch_size=128,
+    epochs=20,
+    validation_split=0.5,
+    callbacks=[
+        # highlight-next-line
+        ReplicateCallback(
+        # highlight-next-line
+            params={"dense_size": dense_size, "learning_rate": learning_rate,},
+        # highlight-next-line
+            primary_metric=("mean_absolute_error", "minimize"),
+        # highlight-next-line
+        ),
+    ],
+)
+```
+
+The `ReplicateCallback` class takes the following arguments, all optional:
+
+- `filepath`: The path where the exported model is saved. This path is also saved by `experiment.checkpoint()` at the end of each epoch. Default: `model.hdf5`
+- `params`: A dictionary of hyperparameters that will be recorded to the experiment at the start of training.
+- `primary_metric`: A tuple in the format `(metric_name, goal)`, where `goal` is either `minimize`, or `maximize`. For example, `("mean_absolute_error", "minimize")`.
+- `save_freq`:`"epoch"` or integer. When using `"epoch"`, the callback saves the model after each epoch. When using integer, the callback saves the model at end of this many batches. Default: `"epoch"`

--- a/web/docs/python.md
+++ b/web/docs/python.md
@@ -18,7 +18,6 @@ You can install the library by adding it to your `requirements.txt` file:
 {`replicate==`+config.customFields.version+`
 `}</CodeBlock>
 
-
 It's a good idea to put it in a file and commit it to Git so other people who use your code will have it installed automatically.
 
 You can also use pip if you are installing it locally:
@@ -70,57 +69,4 @@ For example:
 ...   metrics={"train_loss": 0.425, "train_accuracy": 0.749},
 ...   primary_metric=("train_accuracy", "maximize"),
 ... )
-```
-
-#### `replicate.keras_callback.ReplicateCallback(filepath="model.hdf5", params=None, primary_metric=None, save_freq="epoch")`
-
-_Note: This is an experimental feature, and the API may change in the future._
-
-Replicate provies a convenient callback when you're working with Keras. `ReplicateCallback` behaves like Tensorflow's [ModelCheckpoint callback](https://www.tensorflow.org/api_docs/python/tf/keras/callbacks/ModelCheckpoint), but in addition to exporting a model at the end of each epoch, it also:
-- runs `replicate.init()` to initialize an experiment at the start of training, and
-- runs `experiment.checkpoint()` after saving the model at the end of the epoch (or every _n_ batches if `save_freq` is an integer). This call also saves checkpoint metadata, that it gets from the [`logs` dictionary](https://www.tensorflow.org/guide/keras/custom_callback#a_basic_example) that is passed to the callback's `on_epoch_end` method.
-
-This class takes the following arguments:
-- `filepath`: The path where the exported model is saved. This path is also saved by `experiment.checkpoint()` at the end of each epoch.
-- `params`: A dictionary of hyperparameters that will be recorded to the experiment at the start of training.
-- `primary_metric`: A _pair_ in the format `(metric_name, goal)`, where `goal` is either `minimize`, or `maximize`.
-- `save_freq`:`"epoch"` or integer. When using `"epoch"`, the callback saves the model after each epoch. When using integer, the callback saves the model at end of this many batches.
-
-Example:
-
-```python
-import tensorflow as tf
-from tensorflow import keras
-from replicate.keras_callback import ReplicateCallback
-
-dense_size = 784
-learning_rate = 0.01
-
-# from https://www.tensorflow.org/guide/keras/custom_callback
-model = keras.Sequential()
-model.add(keras.layers.Dense(1, input_dim=dense_size))
-model.compile(
-    optimizer=keras.optimizers.RMSprop(learning_rate=learning_rate),
-    loss="mean_squared_error",
-    metrics=["mean_absolute_error"],
-)
-
-# Load example MNIST data and pre-process it
-(x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data()
-x_train = x_train.reshape(-1, 784).astype("float32") / 255.0
-x_test = x_test.reshape(-1, 784).astype("float32") / 255.0
-
-model.fit(
-    x_train[:1000],
-    y_train[:1000],
-    batch_size=128,
-    epochs=20,
-    validation_split=0.5,
-    callbacks=[
-        ReplicateCallback(
-            params={"dense_size": dense_size, "learning_rate": learning_rate,},
-            primary_metric=("mean_absolute_error", "minimize"),
-        ),
-    ],
-)
 ```

--- a/web/sidebars.js
+++ b/web/sidebars.js
@@ -1,7 +1,7 @@
 module.exports = {
   someSidebar: {
     Tutorial: ["tutorial", "working-with-remote-machines"],
-    Guides: ["how-it-works", "analytics"],
+    Guides: ["how-it-works", "keras-integration", "analytics"],
     Reference: [/*"example-models", */ "python", "replicate-yaml", "cli"],
   },
 };


### PR DESCRIPTION
Because:
- It was hard to link to in the Python reference (the anchor was messed up)
- It was more of a guide anyway
- It was hard to discover
- The reference docs need some organization...

include this sort of thing.

I've also brought the example front and center to make it feel more like a guide, and highlighted the important bits. I'll implement some reference docs when I've reorganized the python reference.