### PR TITLE
Print usage for CLI parsing errors

### DIFF
--- a/cli/pkg/cli/analytics.go
+++ b/cli/pkg/cli/analytics.go
@@ -12,7 +12,7 @@ func newAnalyticsCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "analytics <on|off>",
 		Short: "Enable or disable analytics",
-		RunE:  analyticsCommand,
+		Run:   handleErrors(analyticsCommand),
 		Args:  cobra.ExactArgs(1),
 	}
 }

--- a/cli/pkg/cli/checkout.go
+++ b/cli/pkg/cli/checkout.go
@@ -18,7 +18,7 @@ func newCheckoutCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "checkout <experiment or checkpoint ID>",
 		Short: "Copy files from an experiment or checkpoint into the project directory",
-		RunE:  checkoutCheckpoint,
+		Run:   handleErrors(checkoutCheckpoint),
 		Args:  cobra.ExactArgs(1),
 	}
 

--- a/cli/pkg/cli/common.go
+++ b/cli/pkg/cli/common.go
@@ -80,3 +80,15 @@ func getStorage(storageURL, projectDir string) (storage.Storage, error) {
 	}
 	return store, nil
 }
+
+// handlErrors wraps a cobra function, and will print and exit on error
+//
+// We don't use RunE because if that returns an error, Cobra will print usage.
+// That behavior can be disabled with SilenceUsage option, but then Cobra arg/flag errors don't display usage. (sigh)
+func handleErrors(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		if err := f(cmd, args); err != nil {
+			console.Fatal(err.Error())
+		}
+	}
+}

--- a/cli/pkg/cli/diff.go
+++ b/cli/pkg/cli/diff.go
@@ -24,7 +24,7 @@ func newDiffCommand() *cobra.Command {
 		Long: `Compare two experiments or checkpoints.
 
 If an experiment ID is passed, it will pick the best checkpoint from that experiment. If a primary metric is not defined in replicate.yaml, it will use the latest checkpoint.`,
-		RunE: diffCheckpoints,
+		Run:  handleErrors(diffCheckpoints),
 		Args: cobra.ExactArgs(2),
 	}
 

--- a/cli/pkg/cli/feedback.go
+++ b/cli/pkg/cli/feedback.go
@@ -10,7 +10,7 @@ func newFeedbackCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "feedback",
 		Short: "Submit feedback to the team!",
-		RunE:  submitFeedback,
+		Run:   handleErrors(submitFeedback),
 	}
 
 	return cmd

--- a/cli/pkg/cli/generate_docs.go
+++ b/cli/pkg/cli/generate_docs.go
@@ -14,7 +14,7 @@ func newGenerateDocsCommand(rootCmd *cobra.Command) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "generate-docs",
 		Short:  "",
-		RunE:   generateDocs(rootCmd),
+		Run:    handleErrors(generateDocs(rootCmd)),
 		Args:   cobra.ExactArgs(0),
 		Hidden: true,
 	}

--- a/cli/pkg/cli/list.go
+++ b/cli/pkg/cli/list.go
@@ -14,7 +14,7 @@ func newListCommand() *cobra.Command {
 		Use:     "ls",
 		Short:   "List experiments in this project",
 		Aliases: []string{"list"},
-		RunE:    listExperiments,
+		Run:     handleErrors(listExperiments),
 		Args:    cobra.NoArgs,
 	}
 

--- a/cli/pkg/cli/ps.go
+++ b/cli/pkg/cli/ps.go
@@ -12,7 +12,7 @@ func newPsCommand() *cobra.Command {
 		Use:     "ps",
 		Short:   "List running experiments in this project",
 		Aliases: []string{"processes"},
-		RunE:    listRunningExperiments,
+		Run:     handleErrors(listRunningExperiments),
 		Args:    cobra.NoArgs,
 	}
 

--- a/cli/pkg/cli/rm.go
+++ b/cli/pkg/cli/rm.go
@@ -15,7 +15,7 @@ func newRmCommand() *cobra.Command {
 
 To remove experiments or checkpoints, pass any number of IDs (or prefixes).
 `,
-		RunE:       removeExperimentOrCheckpoint,
+		Run:        handleErrors(removeExperimentOrCheckpoint),
 		Args:       cobra.MinimumNArgs(1),
 		Aliases:    []string{"delete"},
 		SuggestFor: []string{"remove"},

--- a/cli/pkg/cli/root.go
+++ b/cli/pkg/cli/root.go
@@ -21,9 +21,9 @@ func NewRootCommand() (*cobra.Command, error) {
 
 To learn how to get started, go to ` + global.WebURL + `/docs/tutorial`,
 
-		Version:       global.Version,
+		Version: global.Version,
+		// This stops errors being printed because we print them in cmd/replicate/main.go
 		SilenceErrors: true,
-		SilenceUsage:  true,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if global.Verbose {
 				console.SetLevel(console.DebugLevel)

--- a/cli/pkg/cli/run.go
+++ b/cli/pkg/cli/run.go
@@ -34,9 +34,9 @@ func newRunCommand() *cobra.Command {
 		Use:   "run [flags] <command> [arg...]",
 		Short: "Run a command on a remote machine",
 		Args:  cobra.MinimumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Run: handleErrors(func(cmd *cobra.Command, args []string) error {
 			return runCommand(opts, args)
-		},
+		}),
 	}
 
 	flags := cmd.Flags()

--- a/cli/pkg/cli/show.go
+++ b/cli/pkg/cli/show.go
@@ -23,7 +23,7 @@ func newShowCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show <experiment or checkpoint ID>",
 		Short: "View information about an experiment or checkpoint",
-		RunE:  show,
+		Run:   handleErrors(show),
 		Args:  cobra.ExactArgs(1),
 	}
 


### PR DESCRIPTION
Without SilenceUsage, errors in RunE also produce usage, so we have
to make our own wrapper that prints errors without usage.

See also:
https://github.com/spf13/cobra/issues/340
https://github.com/spf13/cobra/issues/914

Closes #159