### PR TITLE
Add --json to replicate show

### DIFF
--- a/cli/pkg/cli/list.go
+++ b/cli/pkg/cli/list.go
@@ -56,6 +56,7 @@ func addListFormatFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolP("quiet", "q", false, "Only print experiment IDs")
 }
 
+// FIXME(bfirsh): use an opts struct and the "Var" version of flag functions to get rid of this
 func parseListFormatFlags(cmd *cobra.Command) (format list.Format, allParams bool, err error) {
 	json, err := cmd.Flags().GetBool("json")
 	if err != nil {

--- a/cli/pkg/cli/show_test.go
+++ b/cli/pkg/cli/show_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path"
@@ -164,6 +165,14 @@ metric-2:   2
 	expected = expected[1:]
 	actual = testutil.TrimRightLines(actual)
 	require.Equal(t, expected, actual)
+
+	// json
+	out = new(bytes.Buffer)
+	err = show(showOpts{storageURL: path.Join(workingDir, ".replicate/storage"), json: true}, []string{"3ccc"}, out)
+	require.NoError(t, err)
+	var chkpt project.Checkpoint
+	require.NoError(t, json.Unmarshal(out.Bytes(), &chkpt))
+	require.Equal(t, "3ccccccccc", chkpt.ID)
 }
 
 func TestShowExperiment(t *testing.T) {
@@ -210,4 +219,14 @@ To see more details about a checkpoint, run:
 	expected = expected[1:]
 	actual = testutil.TrimRightLines(actual)
 	require.Equal(t, expected, actual)
+
+	// json
+	out = new(bytes.Buffer)
+	err = show(showOpts{storageURL: path.Join(workingDir, ".replicate/storage"), json: true}, []string{"1eee"}, out)
+	require.NoError(t, err)
+	var exp experimentShowJSON
+	require.NoError(t, json.Unmarshal(out.Bytes(), &exp))
+	require.Equal(t, "1eeeeeeeee", exp.ID)
+	require.Equal(t, "1ccccccccc", exp.Checkpoints[0].ID)
+
 }


### PR DESCRIPTION
Refactored show to use an options struct rather than accepting
cobra.Command, which means it's possible to test (as per our
conversation about not using integration tests) and makes fetching
flags a bit neater. It would probably make sense to refactor other
commands to do it this way, when we get to them.

Closes #169