### PR TITLE
Put `.replicate` in project dir, not working dir

### DIFF
--- a/python/replicate/config.py
+++ b/python/replicate/config.py
@@ -28,16 +28,15 @@ def load_config(project_dir):
     if "REPLICATE_STORAGE" in os.environ:
         data["storage"] = os.environ["REPLICATE_STORAGE"]
 
-    return validate_and_set_defaults(data)
+    return validate_and_set_defaults(data, project_dir)
 
 
 # TODO(andreas): more rigorous validation
 VALID_KEYS = ["storage", "python", "cuda", "python_requirements", "install", "metrics"]
 REQUIRED_KEYS: List[str] = []
-DEFAULTS = {"storage": ".replicate/storage/", "python": "3.7"}
 
 
-def validate_and_set_defaults(data):
+def validate_and_set_defaults(data, project_dir):
     # TODO (bfirsh): just really simple for now. JSON schema is probably right way (aanand says that is only decent solution)
     for key in REQUIRED_KEYS:
         if key not in data:
@@ -47,7 +46,12 @@ def validate_and_set_defaults(data):
                 )
             )
 
-    for key, value in DEFAULTS.items():
+    defaults = {
+        "storage": os.path.join(project_dir, ".replicate/storage/"),
+        "python": "3.7",
+    }
+
+    for key, value in defaults.items():
         if key not in data:
             data[key] = value
 

--- a/python/replicate/project.py
+++ b/python/replicate/project.py
@@ -13,8 +13,8 @@ class Project:
     Represents a codebase and set of experiments, analogous to a Git repository.
     """
 
-    def __init__(self):
-        self.dir = get_project_dir()
+    def __init__(self, dir=None):
+        self.dir = dir or get_project_dir()
         self.config = load_config(self.dir)
         self.storage = storage_for_url(self.config["storage"])
 

--- a/python/tests/unit/test_config.py
+++ b/python/tests/unit/test_config.py
@@ -1,4 +1,5 @@
 import pytest  # type: ignore
+import os
 
 from replicate.config import (
     load_config,
@@ -13,18 +14,20 @@ def test_load_config_blank(tmp_path):
 
     assert load_config(tmp_path) == {
         "python": "3.7",
-        "storage": ".replicate/storage/",
+        "storage": os.path.join(tmp_path, ".replicate/storage/"),
     }
 
 
 def test_validate():
-    validate_and_set_defaults({"storage": "s3://foobar"})
+    validate_and_set_defaults({"storage": "s3://foobar"}, "/foo")
     with pytest.raises(ConfigValidationError):
-        validate_and_set_defaults({"invalid": "key"})
-        validate_and_set_defaults({"storage": 1234})
-        validate_and_set_defaults({"storage": "s3://foobar", "something": "else"})
+        validate_and_set_defaults({"invalid": "key"}, "/foo")
+        validate_and_set_defaults({"storage": 1234}, "/foo")
+        validate_and_set_defaults(
+            {"storage": "s3://foobar", "something": "else"}, "/foo"
+        )
 
-    assert validate_and_set_defaults({}) == {
+    assert validate_and_set_defaults({}, "/foo") == {
         "python": "3.7",
-        "storage": ".replicate/storage/",
+        "storage": "/foo/.replicate/storage/",
     }


### PR DESCRIPTION
This is a bug fix, but one step towards requiring replicate.yaml
and not depending on working dir for figuring things out.