### PR TITLE
Pass Value as a value, not a pointer

### DIFF
--- a/cli/benchmark/list_test.go
+++ b/cli/benchmark/list_test.go
@@ -81,7 +81,7 @@ func createLotsOfExperiments(workingDir string, storage storage.Storage, numExpe
 
 	for i := 0; i < numExperiments; i++ {
 		err := queue.Go(func() error {
-			exp := project.NewExperiment(map[string]*param.Value{
+			exp := project.NewExperiment(param.ValueMap{
 				"learning_rate": param.Float(0.001),
 			})
 			if err := exp.Save(storage); err != nil {
@@ -94,7 +94,7 @@ func createLotsOfExperiments(workingDir string, storage storage.Storage, numExpe
 
 			exp.Checkpoints = []*project.Checkpoint{}
 			for j := 0; j < numCheckpoints; j++ {
-				exp.Checkpoints = append(exp.Checkpoints, project.NewCheckpoint(map[string]*param.Value{
+				exp.Checkpoints = append(exp.Checkpoints, project.NewCheckpoint(param.ValueMap{
 					"accuracy": param.Float(0.987),
 				}))
 			}

--- a/cli/pkg/cli/diff.go
+++ b/cli/pkg/cli/diff.go
@@ -156,7 +156,7 @@ func experimentToMap(exp *project.Experiment) map[string]string {
 	}
 }
 
-func paramMapToStringMap(params map[string]*param.Value) map[string]string {
+func paramMapToStringMap(params param.ValueMap) map[string]string {
 	result := make(map[string]string)
 	for k, v := range params {
 		result[k] = v.String()

--- a/cli/pkg/cli/list/list.go
+++ b/cli/pkg/cli/list/list.go
@@ -36,23 +36,23 @@ type Metric struct {
 }
 
 type ListExperiment struct {
-	ID               string                  `json:"id"`
-	Created          time.Time               `json:"created"`
-	Params           map[string]*param.Value `json:"params"`
-	Command          string                  `json:"command"`
-	NumCheckpoints   int                     `json:"num_checkpoints"`
-	LatestCheckpoint *project.Checkpoint     `json:"latest_checkpoint"`
-	BestCheckpoint   *project.Checkpoint     `json:"best_checkpoint"`
-	User             string                  `json:"user"`
-	Host             string                  `json:"host"`
-	Running          bool                    `json:"running"`
+	ID               string              `json:"id"`
+	Created          time.Time           `json:"created"`
+	Params           param.ValueMap      `json:"params"`
+	Command          string              `json:"command"`
+	NumCheckpoints   int                 `json:"num_checkpoints"`
+	LatestCheckpoint *project.Checkpoint `json:"latest_checkpoint"`
+	BestCheckpoint   *project.Checkpoint `json:"best_checkpoint"`
+	User             string              `json:"user"`
+	Host             string              `json:"host"`
+	Running          bool                `json:"running"`
 
 	// exclude config from json output
 	Config *config.Config `json:"-"`
 }
 
 // TODO(andreas): make this safer and validate user inputs against these strings
-func (exp *ListExperiment) GetValue(name string) *param.Value {
+func (exp *ListExperiment) GetValue(name string) param.Value {
 	if name == "started" {
 		// floating point timestamp used in sorting
 		return param.Float(float64(exp.Created.Unix()))
@@ -86,7 +86,7 @@ func (exp *ListExperiment) GetValue(name string) *param.Value {
 	if val, ok := exp.Params[name]; ok {
 		return val
 	}
-	return nil
+	return param.None()
 }
 
 func Experiments(store storage.Storage, format Format, all bool, filters *param.Filters, sorter *param.Sorter) error {
@@ -275,7 +275,7 @@ func getParamsToDisplay(experiments []*ListExperiment, all bool) []string {
 			}
 		}
 	} else {
-		paramValues := map[string]*param.Value{}
+		paramValues := param.ValueMap{}
 		for _, exp := range experiments {
 			for key, val := range exp.Params {
 				// Don't show objects in list view, because they're likely long and not very helpful

--- a/cli/pkg/cli/list/list_test.go
+++ b/cli/pkg/cli/list/list_test.go
@@ -27,7 +27,7 @@ func createTestData(t *testing.T, workingDir string, conf *config.Config) storag
 	var experiments = []*project.Experiment{{
 		ID:      "1eeeeeeeee",
 		Created: time.Now().UTC(),
-		Params: map[string]*param.Value{
+		Params: param.ValueMap{
 			"param-1": param.Int(100),
 			"param-2": param.String("hello"),
 		},
@@ -39,7 +39,7 @@ func createTestData(t *testing.T, workingDir string, conf *config.Config) storag
 			{
 				ID:      "1ccccccccc",
 				Created: time.Now().UTC().Add(-1 * time.Minute),
-				Metrics: map[string]*param.Value{
+				Metrics: param.ValueMap{
 					"metric-1": param.Float(0.1),
 					"metric-2": param.Int(2),
 				},
@@ -51,7 +51,7 @@ func createTestData(t *testing.T, workingDir string, conf *config.Config) storag
 			}, {
 				ID:      "2ccccccccc",
 				Created: time.Now().UTC(),
-				Metrics: map[string]*param.Value{
+				Metrics: param.ValueMap{
 					"metric-1": param.Float(0.01),
 					"metric-2": param.Int(2),
 				},
@@ -63,9 +63,11 @@ func createTestData(t *testing.T, workingDir string, conf *config.Config) storag
 			}, {
 				ID:      "3ccccccccc",
 				Created: time.Now().UTC(),
-				Metrics: map[string]*param.Value{
+				Metrics: param.ValueMap{
 					"metric-1": param.Float(0.02),
 					"metric-2": param.Int(2),
+					// test it works with None
+					"metric-3": param.None(),
 				},
 				PrimaryMetric: &project.PrimaryMetric{
 					Name: "metric-1",
@@ -77,7 +79,7 @@ func createTestData(t *testing.T, workingDir string, conf *config.Config) storag
 	}, {
 		ID:      "2eeeeeeeee",
 		Created: time.Now().UTC().Add(-1 * time.Minute),
-		Params: map[string]*param.Value{
+		Params: param.ValueMap{
 			"param-1": param.Int(200),
 			"param-2": param.String("hello"),
 			"param-3": param.String("hi"),
@@ -89,7 +91,7 @@ func createTestData(t *testing.T, workingDir string, conf *config.Config) storag
 			{
 				ID:      "4ccccccccc",
 				Created: time.Now().UTC(),
-				Metrics: map[string]*param.Value{
+				Metrics: param.ValueMap{
 					"metric-3": param.Float(0.5),
 				},
 				PrimaryMetric: &project.PrimaryMetric{
@@ -102,10 +104,12 @@ func createTestData(t *testing.T, workingDir string, conf *config.Config) storag
 	}, {
 		ID:      "3eeeeeeeee",
 		Created: time.Now().UTC().Add(-2 * time.Minute),
-		Params: map[string]*param.Value{
+		Params: param.ValueMap{
 			"param-1": param.Int(200),
 			"param-2": param.String("hello"),
 			"param-3": param.String("hi"),
+			// test it works with None
+			"param-4": param.None(),
 		},
 		Host:   "10.1.1.2",
 		User:   "ben",
@@ -158,10 +162,10 @@ func TestListOutputTableWithPrimaryMetricAll(t *testing.T) {
 	})
 	require.NoError(t, err)
 	expected := `
-EXPERIMENT  STARTED             STATUS   HOST      USER     PARAM-1  PARAM-2  PARAM-3  LATEST CHECKPOINT  METRIC-1  METRIC-2  METRIC-3  BEST CHECKPOINT    METRIC-1  METRIC-2  METRIC-3
-3eeeeee     2 minutes ago       stopped  10.1.1.2  ben      200      hello    hi
-2eeeeee     about a minute ago  stopped  10.1.1.2  andreas  200      hello    hi       4cccccc (step 5)                       0.5
-1eeeeee     about a second ago  running  10.1.1.1  andreas  100      hello             3cccccc (step 20)  0.02      2                   2cccccc (step 20)  0.01      2
+EXPERIMENT  STARTED             STATUS   HOST      USER     PARAM-1  PARAM-2  PARAM-3  PARAM-4  LATEST CHECKPOINT  METRIC-1  METRIC-2  METRIC-3  BEST CHECKPOINT    METRIC-1  METRIC-2  METRIC-3
+3eeeeee     2 minutes ago       stopped  10.1.1.2  ben      200      hello    hi       null
+2eeeeee     about a minute ago  stopped  10.1.1.2  andreas  200      hello    hi                4cccccc (step 5)                       0.5
+1eeeeee     about a second ago  running  10.1.1.1  andreas  100      hello                      3cccccc (step 20)  0.02      2         null      2cccccc (step 20)  0.01      2
 `
 	expected = expected[1:] // strip initial whitespace, added for readability
 	actual = testutil.TrimRightLines(actual)
@@ -254,12 +258,12 @@ func TestListJSON(t *testing.T) {
 	exp := &project.Experiment{
 		ID:      hash.Random(),
 		Created: time.Now().UTC(),
-		Params: map[string]*param.Value{
+		Params: param.ValueMap{
 			"learning_rate": param.Float(0.001),
 		},
 		Command: "train.py --gamma 1.2",
 		Checkpoints: []*project.Checkpoint{
-			project.NewCheckpoint(map[string]*param.Value{
+			project.NewCheckpoint(param.ValueMap{
 				"accuracy": param.Float(0.987),
 			}),
 		},
@@ -272,12 +276,12 @@ func TestListJSON(t *testing.T) {
 	exp = &project.Experiment{
 		ID:      hash.Random(),
 		Created: time.Now().UTC(),
-		Params: map[string]*param.Value{
+		Params: param.ValueMap{
 			"learning_rate": param.Float(0.002),
 		},
 		Command: "train.py --gamma 1.5",
 		Checkpoints: []*project.Checkpoint{
-			project.NewCheckpoint(map[string]*param.Value{
+			project.NewCheckpoint(param.ValueMap{
 				"accuracy": param.Float(0.987),
 			}),
 		},

--- a/cli/pkg/cli/show_test.go
+++ b/cli/pkg/cli/show_test.go
@@ -33,7 +33,7 @@ func createShowTestData(t *testing.T, workingDir string, conf *config.Config) st
 	var experiments = []*project.Experiment{{
 		ID:      "1eeeeeeeee",
 		Created: fixedTime.Add(-10 * time.Minute),
-		Params: map[string]*param.Value{
+		Params: param.ValueMap{
 			"param-1": param.Int(100),
 			"param-2": param.String("hello"),
 		},
@@ -46,7 +46,7 @@ func createShowTestData(t *testing.T, workingDir string, conf *config.Config) st
 				ID:      "1ccccccccc",
 				Created: fixedTime.Add(-5 * time.Minute),
 				Path:    "data",
-				Metrics: map[string]*param.Value{
+				Metrics: param.ValueMap{
 					"metric-1": param.Float(0.1),
 					"metric-2": param.Int(2),
 				},
@@ -59,7 +59,7 @@ func createShowTestData(t *testing.T, workingDir string, conf *config.Config) st
 				ID:      "2ccccccccc",
 				Created: fixedTime.Add(-4 * time.Minute),
 				Path:    "data",
-				Metrics: map[string]*param.Value{
+				Metrics: param.ValueMap{
 					"metric-1": param.Float(0.01),
 					"metric-2": param.Int(2),
 				},
@@ -72,7 +72,7 @@ func createShowTestData(t *testing.T, workingDir string, conf *config.Config) st
 				ID:      "3ccccccccc",
 				Created: fixedTime.Add(-3 * time.Minute),
 				Path:    "data",
-				Metrics: map[string]*param.Value{
+				Metrics: param.ValueMap{
 					"metric-1": param.Float(0.02),
 					"metric-2": param.Int(2),
 				},
@@ -86,7 +86,7 @@ func createShowTestData(t *testing.T, workingDir string, conf *config.Config) st
 	}, {
 		ID:      "2eeeeeeeee",
 		Created: fixedTime.Add(-1 * time.Minute),
-		Params: map[string]*param.Value{
+		Params: param.ValueMap{
 			"param-1": param.Int(200),
 			"param-2": param.String("hello"),
 			"param-3": param.String("hi"),
@@ -99,7 +99,7 @@ func createShowTestData(t *testing.T, workingDir string, conf *config.Config) st
 				ID:      "4ccccccccc",
 				Created: fixedTime.Add(-2 * time.Minute),
 				Path:    "data",
-				Metrics: map[string]*param.Value{
+				Metrics: param.ValueMap{
 					"metric-3": param.Float(0.5),
 				},
 				Step: 5,

--- a/cli/pkg/param/filter.go
+++ b/cli/pkg/param/filter.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ValueGetter interface {
-	GetValue(name string) *Value
+	GetValue(name string) Value
 }
 
 type Filters struct {
@@ -19,7 +19,7 @@ type Filters struct {
 type filter struct {
 	name     string
 	operator Operator
-	value    *Value
+	value    Value
 }
 
 type Operator int
@@ -47,7 +47,7 @@ func MakeFilters(strings []string) (*Filters, error) {
 
 // SetExclusive sets a filter exclusively, deleting any previous
 // filters with that name
-func (fs *Filters) SetExclusive(name string, operator Operator, value *Value) {
+func (fs *Filters) SetExclusive(name string, operator Operator, value Value) {
 	filters := []*filter{{
 		name:     name,
 		operator: operator,
@@ -85,9 +85,6 @@ func (fs *Filters) Matches(obj ValueGetter) (bool, error) {
 
 func (f *filter) matches(obj ValueGetter) (bool, error) {
 	value := obj.GetValue(f.name)
-	if value == nil {
-		return f.value.IsNone() && f.operator == OperatorEqual, nil
-	}
 	if f.value.IsNone() {
 		if f.operator == OperatorEqual {
 			return value.IsNone(), nil

--- a/cli/pkg/param/map.go
+++ b/cli/pkg/param/map.go
@@ -4,18 +4,21 @@ import (
 	"encoding/json"
 )
 
-type ValueMap map[string]*Value
+type ValueMap map[string]Value
+
+type pointerValueMap map[string]*Value
 
 func (m *ValueMap) UnmarshalJSON(data []byte) error {
-	// https://stackoverflow.com/questions/43176625/call-json-unmarshal-inside-unmarshaljson-function-without-causing-stack-overflow
-	type valuemap2 ValueMap
-	if err := json.Unmarshal(data, (*valuemap2)(m)); err != nil {
+	var pointerMap pointerValueMap
+	if err := json.Unmarshal(data, &pointerMap); err != nil {
 		return err
 	}
-	mval := *m
-	for k := range mval {
-		if mval[k] == nil {
-			mval[k] = None()
+	*m = make(ValueMap)
+	for k, v := range pointerMap {
+		if v == nil {
+			(*m)[k] = None()
+		} else {
+			(*m)[k] = *v
 		}
 	}
 	return nil

--- a/cli/pkg/param/map_test.go
+++ b/cli/pkg/param/map_test.go
@@ -1,0 +1,22 @@
+package param
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalJSON(t *testing.T) {
+	valmap := make(ValueMap)
+
+	require.NoError(t, json.Unmarshal([]byte(`{"foo": 1}`), &valmap))
+	require.Equal(t, ValueMap(ValueMap{"foo": Int(1)}), valmap)
+
+	require.NoError(t, json.Unmarshal([]byte(`{"foo": {"baz": "bop"}}`), &valmap))
+	require.Equal(t, ValueMap(ValueMap{"foo": Object(map[string]interface{}{"baz": "bop"})}), valmap)
+
+	require.NoError(t, json.Unmarshal([]byte(`{"foo": null}`), &valmap))
+	require.Equal(t, ValueMap(ValueMap{"foo": None()}), valmap)
+
+}

--- a/cli/pkg/param/sort.go
+++ b/cli/pkg/param/sort.go
@@ -25,16 +25,10 @@ func (s *Sorter) LessThan(x ValueGetter, y ValueGetter) bool {
 	xVal := x.GetValue(s.Key)
 	yVal := y.GetValue(s.Key)
 	var isLess bool
-	if xVal == nil {
-		isLess = true
-	} else if yVal == nil {
-		isLess = false
-	} else {
-		var err error
-		isLess, err = xVal.LessThan(yVal)
-		if err != nil {
-			panic(err)
-		}
+	var err error
+	isLess, err = xVal.LessThan(yVal)
+	if err != nil {
+		panic(err)
 	}
 	if s.Descending {
 		return !isLess

--- a/cli/pkg/project/checkpoint.go
+++ b/cli/pkg/project/checkpoint.go
@@ -31,7 +31,7 @@ type Checkpoint struct {
 }
 
 // NewCheckpoint creates a checkpoint with default values
-func NewCheckpoint(metrics map[string]*param.Value) *Checkpoint {
+func NewCheckpoint(metrics param.ValueMap) *Checkpoint {
 	return &Checkpoint{
 		ID:      hash.Random(),
 		Created: time.Now().UTC(),

--- a/cli/pkg/project/experiment.go
+++ b/cli/pkg/project/experiment.go
@@ -28,12 +28,12 @@ type Experiment struct {
 
 type NamedParam struct {
 	Name  string
-	Value *param.Value
+	Value param.Value
 }
 
 // NewExperiment creates an experiment, setting ID and Created
 // TODO(andreas): can we get rid of this function?
-func NewExperiment(params map[string]*param.Value) *Experiment {
+func NewExperiment(params param.ValueMap) *Experiment {
 	return &Experiment{
 		ID:      hash.Random(),
 		Created: time.Now().UTC(),


### PR DESCRIPTION
`null` in JSON was being unmarshaled as `nil`, not `param.None()`.
I implemented a quick fix in #207, but this is the proper fix.
This removes a whole class of null pointer bugs.