### PR TITLE
Make init() and checkpoint() never throw exception

### DIFF
--- a/cli/benchmark/big_project/make_big_project.py
+++ b/cli/benchmark/big_project/make_big_project.py
@@ -19,7 +19,7 @@ with tempfile.TemporaryDirectory() as project_dir:
         if i % 10 == 0:
             print("Experiment", i)
         experiment = project.experiments.create(
-            path=None, params={"foo": "bar"}, quiet=True
+            path=None, params={"foo": "bar"}, quiet=True, disable_heartbeat=True
         )
         for j in range(100):
             experiment.checkpoint(path=None, metrics={"loss": 0.00001}, quiet=True)
@@ -33,7 +33,7 @@ with tempfile.TemporaryDirectory() as project_dir:
         experiment.checkpoint(path=None, metrics={"loss": 0.00001}, quiet=True)
     for i in range(10):
         experiment = project.experiments.create(
-            path=None, params={"foo": "bar"}, quiet=True
+            path=None, params={"foo": "bar"}, quiet=True, disable_heartbeat=True
         )
         for j in range(100):
             experiment.checkpoint(path=None, metrics={"loss": 0.00001}, quiet=True)

--- a/python/replicate/console.py
+++ b/python/replicate/console.py
@@ -1,4 +1,5 @@
 import enum
+from functools import wraps
 import sys
 
 from ._vendor.colors import color
@@ -46,3 +47,22 @@ def log(s: str, level: Level):
             print(prompt + line, file=sys.stderr)
         else:
             print(continuation_prompt + line, file=sys.stderr)
+
+
+# Replicate should never break your training
+def catch_and_print_exceptions(msg=None, return_value=None):
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            try:
+                return f(*args, **kwargs)
+            except Exception as e:  # pylint: disable=broad-except
+                if msg is not None:
+                    error(f"{msg}: {str(e)}")
+                else:
+                    error(str(e))
+                return return_value
+
+        return wrapper
+
+    return decorator

--- a/python/replicate/project.py
+++ b/python/replicate/project.py
@@ -61,12 +61,9 @@ def init(
     Create a new experiment.
     """
     project = Project()
-    experiment = project.experiments.create(path=path, params=params)
-
-    if not disable_heartbeat:
-        experiment.start_heartbeat()
-
-    return experiment
+    return project.experiments.create(
+        path=path, params=params, disable_heartbeat=disable_heartbeat
+    )
 
 
 def get_project_dir() -> str:

--- a/python/tests/unit/test_checkpoint.py
+++ b/python/tests/unit/test_checkpoint.py
@@ -93,7 +93,9 @@ class TestCheckpoint:
         with open("foo.txt", "w") as f:
             f.write("foo")
 
-        exp = project.experiments.create(path=".", params={"foo": "bar"})
+        exp = project.experiments.create(
+            path=".", params={"foo": "bar"}, disable_heartbeat=True
+        )
         with open("bar.txt", "w") as f:
             f.write("bar")
         chk = exp.checkpoint(path="bar.txt", metrics={"accuracy": "awesome"})
@@ -121,7 +123,9 @@ class TestCheckpoint:
         with open("foo.txt", "w") as f:
             f.write("foo")
 
-        exp = project.experiments.create(path=".", params={"foo": "bar"})
+        exp = project.experiments.create(
+            path=".", params={"foo": "bar"}, disable_heartbeat=True
+        )
         with open("bar.txt", "w") as f:
             f.write("bar")
         chk = exp.checkpoint(path="bar.txt", metrics={"accuracy": "awesome"})


### PR DESCRIPTION
Replicate should never break your training.

<img width="652" alt="Screen Shot 2020-10-24 at 17 20 56" src="https://user-images.githubusercontent.com/40906/97096189-486e8f80-161d-11eb-96fb-56bd33a7b16a.png">

An improvement on this would be to dump real errors to a file so we can get the traceback. User errors (e.g. access denied to S3 bucket) would not do this. I figure the most important thing is to be robust and not break your training though, which is my reasoning behind having a catch-all and then working back.