### PR TITLE
Check out best/latest checkpoint with experiment

### DIFF
--- a/cli/pkg/cli/checkout.go
+++ b/cli/pkg/cli/checkout.go
@@ -84,14 +84,34 @@ func checkoutCheckpoint(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	displayPath := filepath.Join(outputDir, result.Experiment.Path)
+	experiment := result.Experiment
+	checkpoint := result.Checkpoint
 
-	// FIXME(bfirsh): this is a bodge and isn't always quite right -- if no experiment path set, and we're checking out checkpoint, display the checkpoint path
-	if result.Experiment.Path == "" && result.Checkpoint != nil {
-		displayPath = filepath.Join(outputDir, result.Checkpoint.Path)
+	if checkpoint != nil {
+		console.Info("Checking out files from checkpoint %s and its experiment %s", checkpoint.ShortID(), experiment.ShortID())
+	} else {
+		// When checking out experiment, also check out best/latest checkpoint
+		checkpoint = experiment.BestCheckpoint()
+		if checkpoint != nil {
+			console.Info("Checking out files from experiment %s and its best checkpoint %s", experiment.ShortID(), checkpoint.ShortID())
+		} else {
+			checkpoint = experiment.LatestCheckpoint()
+			if checkpoint != nil {
+				console.Info("Checking out files from experiment %s and its latest checkpoint %s", experiment.ShortID(), checkpoint.ShortID())
+			} else {
+				console.Info("Checking out files from experiment %s", experiment.ShortID())
+			}
+		}
 	}
 
-	isEmpty, err := files.DirIsEmpty(outputDir)
+	displayPath := filepath.Join(outputDir, experiment.Path)
+
+	// FIXME(bfirsh): this is a bodge and isn't always quite right -- if no experiment path set, and we're checking out checkpoint, display the checkpoint path
+	if experiment.Path == "" && checkpoint != nil {
+		displayPath = filepath.Join(outputDir, checkpoint.Path)
+	}
+
+	isEmpty, err := files.DirIsEmpty(displayPath)
 	if err != nil {
 		return err
 	}
@@ -114,53 +134,52 @@ func checkoutCheckpoint(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	msg := ""
-	experiment := result.Experiment
+	fmt.Fprintln(os.Stderr)
 
-	if result.Checkpoint != nil {
-		// Checking out checkpoint
-		checkpoint := result.Checkpoint
+	experimentFilesExist := true
+	checkpointFilesExist := true
 
-		if err := store.GetPathTar(path.Join("experiments", experiment.ID+".tar.gz"), outputDir); err != nil {
-			// Ignore does not exist errors
-			if _, ok := err.(*storage.DoesNotExistError); !ok {
-				return err
-			}
-		}
-		// Overlay checkpoint on top of experiment
-		if err := store.GetPathTar(path.Join("checkpoints", checkpoint.ID+".tar.gz"), outputDir); err != nil {
-			if _, ok := err.(*storage.DoesNotExistError); ok {
-				return fmt.Errorf(`Could not check out this checkpoint because it does not have any files associated with it.
-
-You need to set the 'path' option on 'checkpoint()' to check them out.`)
-			}
+	if err := store.GetPathTar(path.Join("experiments", experiment.ID+".tar.gz"), outputDir); err != nil {
+		// Ignore does not exist errors
+		if _, ok := err.(*storage.DoesNotExistError); ok {
+			console.Debug("No experiment data found")
+			experimentFilesExist = false
+		} else {
 			return err
 		}
-
-		// TODO: actually mention which files were checked out
-		msg += fmt.Sprintf("Copied the files from checkpoint %s to %q\n", checkpoint.ShortID(), displayPath)
-
 	} else {
-		// Checking out experiment
-		if err := store.GetPathTar(path.Join("experiments", experiment.ID+".tar.gz"), outputDir); err != nil {
-			if _, ok := err.(*storage.DoesNotExistError); ok {
-				return fmt.Errorf(`Could not check out this experiment because it does not have any files associated with it.
-
-You need to set the 'path' option on 'init()' to check experiments out.`)
-			}
-			return err
-		}
-
-		msg += fmt.Sprintf("Copied the files from experiment %s to %q\n", experiment.ShortID(), displayPath)
+		console.Info("Copied the files from experiment %s to %q", experiment.ShortID(), filepath.Join(outputDir, experiment.Path))
 	}
 
-	msg += "\n"
-	msg += "If you want to run this experiment again, this is how it was run:\n"
-	msg += "\n"
-	msg += "  " + experiment.Command
-	msg += "\n"
-	fmt.Fprintln(os.Stderr)
-	console.Info(msg)
+	// Overlay checkpoint on top of experiment
+	if checkpoint != nil {
+
+		if err := store.GetPathTar(path.Join("checkpoints", checkpoint.ID+".tar.gz"), outputDir); err != nil {
+			if _, ok := err.(*storage.DoesNotExistError); ok {
+				console.Debug("No checkpoint data found")
+				checkpointFilesExist = false
+			} else {
+				return err
+
+			}
+		} else {
+			console.Info("Copied the files from checkpoint %s to %q", checkpoint.ShortID(), filepath.Join(outputDir, checkpoint.Path))
+		}
+
+	}
+
+	if !experimentFilesExist && !checkpointFilesExist {
+		// Just an experiment, no checkpoints
+		if checkpoint == nil {
+			return fmt.Errorf("The experiment %s does not have any files associated with it. You need to pass the 'path' argument to 'init()' to check out files.", experiment.ShortID())
+		}
+		return fmt.Errorf("Neither the experiment %s nor the checkpoint %s has any files associated with it. You need to pass the 'path' argument to 'init()' or 'checkpoint()' to check out files.", experiment.ShortID(), checkpoint.ShortID())
+	}
+
+	console.Info(`If you want to run this experiment again, this is how it was run:
+
+  ` + experiment.Command + `
+`)
 
 	return nil
 }

--- a/end-to-end-test/end_to_end_test/test_checkout.py
+++ b/end-to-end-test/end_to_end_test/test_checkout.py
@@ -96,10 +96,14 @@ if __name__ == "__main__":
     with open(os.path.join(output_dir, rand, rand)) as f:
         assert f.read() == rand
 
+    # Checkout out experiment checks out latest checkpoint
+    with open(os.path.join(output_dir, "data/weights")) as f:
+        assert f.read() == "42 lbs"
+
     actual_paths = [
         os.path.relpath(path, output_dir) for path in glob(output_dir + "/*")
     ]
-    expected_paths = ["replicate.yaml", "train.py", rand, "cicada.ogg"]
+    expected_paths = ["replicate.yaml", "train.py", "data", rand, "cicada.ogg"]
     assert set(actual_paths) == set(expected_paths)
 
     # checking out checkpoint


### PR DESCRIPTION
... and really clearly tell the user what is going to happen.

This fixes issue Chris had where he was only saving data on checkpoint,
and understandably expected data to be checked out when he checked
out experiment.

Not very pretty but things will move around when there is progress bars:

<img width="639" alt="Screen Shot 2020-10-26 at 13 13 59" src="https://user-images.githubusercontent.com/40906/97223524-1e3bdf80-178d-11eb-8171-3020137357fe.png">