### PR TITLE
Add underscore prefix to Experiment save and validate methods (#64)

### DIFF
--- a/python/keepsake/experiment.py
+++ b/python/keepsake/experiment.py
@@ -68,7 +68,7 @@ class Experiment:
     def short_id(self):
         return self.id[:7]
 
-    def validate(self) -> List[str]:
+    def _validate(self) -> List[str]:
         errors = []
 
         if self.params is not None:
@@ -140,10 +140,10 @@ class Experiment:
             quiet=quiet,
         )
         self.checkpoints.append(checkpoint)
-        self.save(quiet=quiet)
+        self._save(quiet=quiet)
         return checkpoint
 
-    def save(self, quiet: bool):
+    def _save(self, quiet: bool):
         """
         Save this experiment's metadata to repository.
         """

--- a/python/tests/test_experiment.py
+++ b/python/tests/test_experiment.py
@@ -255,25 +255,27 @@ class TestExperiment:
         }
 
         experiment = Experiment(path=None, params="lol", **kwargs)
-        assert experiment.validate() == ["params must be a dictionary"]
+        assert experiment._validate() == ["params must be a dictionary"]
 
         experiment = Experiment(path=None, params={"foo": Blah()}, **kwargs)
-        assert "Failed to serialize the param 'foo' to JSON" in experiment.validate()[0]
+        assert (
+            "Failed to serialize the param 'foo' to JSON" in experiment._validate()[0]
+        )
 
         experiment = Experiment(path="..", **kwargs)
         assert (
             "The path passed to the experiment must not start with '..' or '/'."
-            in experiment.validate()[0]
+            in experiment._validate()[0]
         )
         experiment = Experiment(path="/", **kwargs)
         assert (
             "The path passed to the experiment must not start with '..' or '/'."
-            in experiment.validate()[0]
+            in experiment._validate()[0]
         )
         experiment = Experiment(path="blah", **kwargs)
         assert (
             "The path passed to the experiment does not exist: blah"
-            in experiment.validate()[0]
+            in experiment._validate()[0]
         )
 
     def test_checkpoints(self, temp_workdir):


### PR DESCRIPTION
Rename the class `Experiment` methods `save` and `validate` to `_save` and `_validate` as pointed out in #64.