### PR TITLE
updated Colab notebook to use keepsake instead of replicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ pip install -U keepsake
 
 If you prefer **training scripts and the CLI**, [follow the our tutorial to learn how Keepsake works](https://keepsake.ai/docs/tutorial).
 
-If you prefer **working in notebooks**, <a href="https://colab.research.google.com/drive/1vjZReg--45P-NZ4j8TXAJFWuepamXc7K" target="_blank">follow our notebook tutorial on Colab</a>.
+If you prefer **working in notebooks**, <a href="https://colab.research.google.com/drive/1gcdRX-QkWO1PaLxhGDBR_sRKv6KT7-qQ?usp=sharing" target="_blank">follow our notebook tutorial on Colab</a>.
 
 If you like to **learn concepts first**, [read our guide about how Keepsake works](https://keepsake.ai/docs/learn/how-it-works).
 


### PR DESCRIPTION
Hey guys, is the package supposed to be replicate or keepsake?
If it's the keepsake, then Colab notebook uses old package name.
I fixed that in Colab and updated link to new notebook.