### PR TITLE
Remove quotes from ConfigNotFound error message

### DIFF
--- a/go/pkg/errors/errors.go
+++ b/go/pkg/errors/errors.go
@@ -54,7 +54,7 @@ func ConfigNotFound(msg string) error {
 
 You must either create a keepsake.yaml configuration file, or explicitly pass the arguments 'repository' and 'directory' to keepsake.Project().
 
-For more information, see https://keepsake.ai/docs/reference/python"""
+For more information, see https://keepsake.ai/docs/reference/python
 `,
 	}
 }


### PR DESCRIPTION
Signed-off-by: Tushar Mittal <chiragmittal.mittal@gmail.com>

The `ConfigNotFound` error message had `"""` quotes at the end of URL which were redirecting to [https://keepsake.ai/docs/reference/python%22%22%22](https://keepsake.ai/docs/reference/python""") and this page is giving `404 Not Found`.

I am not sure if this is the expected behaviour 😅 

Python Version: 3.7 running on Jupyter Notebook

<img width="1010" alt="Screenshot 2021-03-09 at 4 07 33 PM" src="https://user-images.githubusercontent.com/26834658/110458469-cd9ca180-80f1-11eb-827f-7624c0dc68be.png">
