### PR TITLE
respect AWS_DEFAULT_REGION env var

### DIFF
--- a/go/benchmark/list_test.go
+++ b/go/benchmark/list_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/replicate/keepsake/go/pkg/concurrency"
+	"github.com/replicate/keepsake/go/pkg/global"
 	"github.com/replicate/keepsake/go/pkg/hash"
 	"github.com/replicate/keepsake/go/pkg/param"
 	"github.com/replicate/keepsake/go/pkg/project"
@@ -162,10 +163,10 @@ func BenchmarkKeepsakeS3(b *testing.B) {
 
 	// Create a bucket
 	bucketName := "keepsake-test-benchmark-" + hash.Random()[0:10]
-	err = repository.CreateS3Bucket("us-east-1", bucketName)
+	err = repository.CreateS3Bucket(global.S3Region, bucketName)
 	require.NoError(b, err)
 	defer func() {
-		require.NoError(b, repository.DeleteS3Bucket("us-east-1", bucketName))
+		require.NoError(b, repository.DeleteS3Bucket(global.S3Region, bucketName))
 	}()
 	// Even though CreateS3Bucket is supposed to wait until it exists, sometimes it doesn't
 	time.Sleep(1 * time.Second)

--- a/go/pkg/cli/daemon.go
+++ b/go/pkg/cli/daemon.go
@@ -15,6 +15,7 @@ func NewDaemonCommand() *cobra.Command {
 		RunE: runDaemon,
 	}
 	setPersistentFlags(cmd)
+	handleEnvironmentVariables()
 	addRepositoryURLFlag(cmd)
 	return cmd
 }

--- a/go/pkg/cli/root.go
+++ b/go/pkg/cli/root.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/replicate/keepsake/go/pkg/analytics"
@@ -34,6 +36,7 @@ To learn how to get started, go to ` + global.WebURL + `/docs/tutorial`,
 		},
 	}
 	setPersistentFlags(&rootCmd)
+	handleEnvironmentVariables()
 
 	rootCmd.AddCommand(
 		newAnalyticsCommand(),
@@ -56,4 +59,10 @@ func setPersistentFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&global.ProjectDirectory, "project-directory", "D", "", "Project directory. Default: nearest parent directory with keepsake.yaml")
 	cmd.PersistentFlags().BoolVarP(&global.Verbose, "verbose", "v", false, "Verbose output")
 
+}
+
+func handleEnvironmentVariables() {
+	if s3Region := os.Getenv("AWS_DEFAULT_REGION"); s3Region != "" {
+		global.S3Region = s3Region
+	}
 }

--- a/go/pkg/global/variables.go
+++ b/go/pkg/global/variables.go
@@ -11,6 +11,7 @@ var Color = true
 var ProjectDirectory = ""
 var BugsEmail = "bugs@replicate.ai"
 var SegmentKey = "MKaYmSZ2hW6P8OegI9g0sufjZeUh28g7"
+var S3Region = "us-east-1"
 
 func init() {
 	if Environment == "development" {

--- a/go/pkg/repository/s3.go
+++ b/go/pkg/repository/s3.go
@@ -23,6 +23,7 @@ import (
 	"github.com/replicate/keepsake/go/pkg/console"
 	"github.com/replicate/keepsake/go/pkg/errors"
 	"github.com/replicate/keepsake/go/pkg/files"
+	"github.com/replicate/keepsake/go/pkg/global"
 )
 
 type S3Repository struct {
@@ -449,7 +450,7 @@ func (s *S3Repository) listRecursive(results chan<- ListResult, dir string, filt
 func discoverBucketRegion(bucket string) (string, error) {
 	sess := session.Must(session.NewSession(&aws.Config{}))
 	ctx := context.Background()
-	region, err := s3manager.GetBucketRegion(ctx, sess, bucket, "us-east-1")
+	region, err := s3manager.GetBucketRegion(ctx, sess, bucket, global.S3Region)
 	if err != nil {
 		return "", err
 	}
@@ -464,8 +465,7 @@ func getBucketRegionOrCreateBucket(bucket string) (string, error) {
 			// The real check for this is `aerr.Code() == s3.ErrCodeNoSuchBucket` but GetBucketRegion doesnt return right error
 			if strings.Contains(aerr.Error(), "NotFound") {
 				// TODO (bfirsh): report to use that this is being created, in a way that is compatible with shared library
-				region = "us-east-1"
-				if err := CreateS3Bucket(region, bucket); err != nil {
+				if err := CreateS3Bucket(global.S3Region, bucket); err != nil {
 					return "", fmt.Errorf("Error creating bucket: %v", err)
 				}
 				return region, nil

--- a/go/pkg/repository/s3_test.go
+++ b/go/pkg/repository/s3_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/replicate/keepsake/go/pkg/errors"
 	"github.com/replicate/keepsake/go/pkg/files"
+	"github.com/replicate/keepsake/go/pkg/global"
 	"github.com/replicate/keepsake/go/pkg/hash"
 )
 
@@ -116,18 +117,18 @@ func TestS3ListRecursive(t *testing.T) {
 
 func createS3Bucket(t *testing.T) (string, *s3.S3) {
 	bucketName := "keepsake-test-go-" + hash.Random()[0:10]
-	err := CreateS3Bucket("us-east-1", bucketName)
+	err := CreateS3Bucket(global.S3Region, bucketName)
 	require.NoError(t, err)
 
 	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("us-east-1"),
+		Region: aws.String(global.S3Region),
 	})
 	require.NoError(t, err)
 	return bucketName, s3.New(sess)
 }
 
 func deleteS3Bucket(t *testing.T, bucketName string) {
-	require.NoError(t, DeleteS3Bucket("us-east-1", bucketName))
+	require.NoError(t, DeleteS3Bucket(global.S3Region, bucketName))
 }
 
 func readS3Object(t *testing.T, svc *s3.S3, bucketName string, key string) []byte {


### PR DESCRIPTION
Lets the user override the hardcoded s3 region (currently `us-east-1`).