### PR TITLE
Add --full flag to ls command

### DIFF
--- a/go/pkg/cli/list.go
+++ b/go/pkg/cli/list.go
@@ -66,6 +66,7 @@ func listExperiments(cmd *cobra.Command, args []string) error {
 func addListFormatFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("json", false, "Print output in JSON format")
 	cmd.Flags().Bool("all", false, "Output all params and metrics. Default: only params/metrics that differ")
+	cmd.Flags().Bool("full", false, "Do not truncate parameter values.")
 	cmd.Flags().BoolP("quiet", "q", false, "Only print experiment IDs")
 }
 
@@ -81,12 +82,26 @@ func parseListFormatFlags(cmd *cobra.Command) (format list.Format, all bool, err
 		format = list.FormatTable
 	}
 
+	full, err := cmd.Flags().GetBool("full")
+	if err != nil {
+		return 0, false, err
+	}
+	if full && format == list.FormatJSON {
+		return 0, false, fmt.Errorf("Cannot use the --full flag in combination with --json")
+	}
+	if full {
+		format = list.FormatFullTable
+	}
+
 	quiet, err := cmd.Flags().GetBool("quiet")
 	if err != nil {
 		return 0, false, err
 	}
 	if quiet && format == list.FormatJSON {
 		return 0, false, fmt.Errorf("Cannot use the --quiet flag in combination with --json")
+	}
+	if quiet && full {
+		return 0, false, fmt.Errorf("Cannot use the --quiet flag in combination with --full")
 	}
 
 	all, err = cmd.Flags().GetBool("all")

--- a/go/pkg/cli/list/list.go
+++ b/go/pkg/cli/list/list.go
@@ -25,6 +25,7 @@ const (
 	FormatJSON = iota
 	FormatTable
 	FormatQuiet
+	FormatFullTable
 )
 
 const valueMaxLength = 20
@@ -98,7 +99,9 @@ func Experiments(repo repository.Repository, format Format, all bool, filters *p
 	case FormatJSON:
 		return outputJSON(listExperiments)
 	case FormatTable:
-		return outputTable(listExperiments, all)
+		return outputTable(listExperiments, all, true)
+	case FormatFullTable:
+		return outputTable(listExperiments, all, false)
 	case FormatQuiet:
 		return outputQuiet(listExperiments)
 	}
@@ -118,7 +121,7 @@ func outputJSON(experiments []*ListExperiment) error {
 	return enc.Encode(experiments)
 }
 
-func outputTable(experiments []*ListExperiment, all bool) error {
+func outputTable(experiments []*ListExperiment, all bool, truncate bool) error {
 	if len(experiments) == 0 {
 		console.Info("No experiments found")
 		return nil
@@ -191,7 +194,11 @@ func outputTable(experiments []*ListExperiment, all bool) error {
 		params := []string{}
 		for _, key := range paramsToDisplay {
 			if val, ok := exp.Params[key]; ok {
-				params = append(params, key+"="+val.ShortString(valueMaxLength, valueTruncate))
+				if truncate {
+					params = append(params, key+"="+val.ShortString(valueMaxLength, valueTruncate))
+				} else {
+					params = append(params, key+"="+val.String())
+				}
 			}
 		}
 		columns = append(columns, strings.Join(params, "\n"))


### PR DESCRIPTION
Currently `keepsake ls` command truncates experiment parameter values. This PR adds `--full` option to disable this behavior. Personally, I found the feature useful for displaying long string parameters in one go (e.g, loss, list of features, comment).