### PR TITLE
Solve a TypeError with IPython

### DIFF
--- a/python/keepsake/daemon.py
+++ b/python/keepsake/daemon.py
@@ -239,7 +239,7 @@ def start_wrapped_pipe(pipe, writer):
     def wrap_pipe(pipe, writer):
         with pipe:
             for line in iter(pipe.readline, b""):
-                writer.write(line)
+                writer.write(line.decode("utf-8"))
                 writer.flush()
 
     # if writer is normal sys.std{out,err}, it can't


### PR DESCRIPTION
Work around when working with latest versions of IPython `TypeError: write() argument must be str, not <class 'bytes'>`